### PR TITLE
Fix PPPoS driver and improve modem performance

### DIFF
--- a/drivers/pppos.c
+++ b/drivers/pppos.c
@@ -288,9 +288,9 @@ static int at_disconnect(int fd) {
 static int at_is_responding(int fd, int timeout_ms)
 {
 	int res;
-	int retry = 10;
+	int retry = 5;
 
-	while ((res = at_send_cmd(fd, "AT\r\n", timeout_ms * 1000)) != AT_RESULT_OK && retry--);
+	while ((res = at_send_cmd(fd, "AT\r\n", timeout_ms)) != AT_RESULT_OK && retry--);
 
 	if (res != AT_RESULT_OK) {
 		log_warn("modem not responding, res=%d", res);

--- a/modem/quectel/pppos_modem.h
+++ b/modem/quectel/pppos_modem.h
@@ -24,6 +24,7 @@ static const char* at_init_cmds[] = {
 	"ATZ\r\n",        // reset MODEM
 	"ATE0\r\n",        // disable command echo
 	"AT+QSCLK=0\r\n",        // disable automatic deep sleep
+	"AT+CGATT=0\r\n",        // detach from PDN
 	"AT+QCFG=\"autopdn\",0\r\n",        // disable automatic PDN attach (to allow PPP)
 	"AT+CREG?\r\n",        // check network registration (just for debug)
 	"AT+COPS?\r\n",        // check operator registration (just for debug)


### PR DESCRIPTION
The timeout value for the initial `AT` command was unnecessarily multiplied. This made lwip trip over and block for several hours if the modem had not responded immediately. The retry count was also decreased because there is no point in waiting so long for a modem which has woken improperly.

Even though `AT+QCFG="autopdn",0` command is issued, the modem usually errors out when trying to establish a PPP connection (by error, `ERROR` return code for `CONNECT` command is meant). Addition of `AT+CGATT=0` resulted in 100% success rate of PPP connections, compared to ~30% without `AT+CGATT=0`.