### PR TITLE
Unify use of the rid parameter of msgRecv, msgRespond functions

### DIFF
--- a/drivers/tuntap.c
+++ b/drivers/tuntap.c
@@ -139,7 +139,7 @@ static void tuntap_mainLoop(void* _state)
 {
 	tuntap_priv_t *state = _state;
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	while (1) {
 		if (msgRecv(state->port, &msg, &rid) < 0) {

--- a/port/main.c
+++ b/port/main.c
@@ -119,7 +119,7 @@ static int readPf(void *buffer, size_t size, size_t offset)
 static void mainLoop(void)
 {
 	msg_t msg = {0};
-	unsigned int rid;
+	unsigned long int rid;
 	unsigned port;
 	oid_t route_oid = {0, 0};
 	oid_t status_oid = {0, 1};


### PR DESCRIPTION
Accordingly to phoenix-rtos/libphoenix#70 (comment)