### PR TITLE
pppos connect change

### DIFF
--- a/drivers/pppos.c
+++ b/drivers/pppos.c
@@ -114,12 +114,14 @@ static void serial_set_non_blocking(int fd)
 		log_error("%s() : fcntl(%d, O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
 }
 
+#if 0
 static void serial_set_blocking(int fd)
 {
 	int flags = fcntl(fd, F_GETFL, 0);
 	if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
 		log_error("%s() : fcntl(%d, ~O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
 }
+#endif
 
 #define WRITE_MAX_RETRIES 2
 static int serial_write(int fd, const u8_t* data, u32_t len)
@@ -271,6 +273,8 @@ static int at_send_cmd(int fd, const char* cmd, int timeout_ms)
 
 
 // NOTE: this only disconnects the AT modem from the data connection
+// Currently only used in initialisation
+#if PPPOS_DISCONNECT_ON_INIT
 static int at_disconnect(int fd) {
 	// TODO: do it better (finite retries? broken?)
 	int res;
@@ -283,7 +287,7 @@ static int at_disconnect(int fd) {
 
 	return res;
 }
-
+#endif
 
 static int at_is_responding(int fd, int timeout_ms)
 {

--- a/port/sockets.c
+++ b/port/sockets.c
@@ -37,7 +37,7 @@
 #include "route.h"
 
 #define SOCKTHREAD_PRIO 4
-#define SOCKTHREAD_STACKSZ (4 * SIZE_PAGE)
+#define SOCKTHREAD_STACKSZ (4 * _PAGE_SIZE)
 
 
 struct sock_start {
@@ -588,7 +588,7 @@ static int socket_op(msg_t *msg, int sock)
 static void socket_thread(void *arg)
 {
 	struct sock_start *ss = arg;
-	unsigned respid;
+	unsigned long respid;
 	uint32_t port = ss->port;
 	int sock = ss->sock, err;
 	msg_t msg;
@@ -740,13 +740,15 @@ static int do_getaddrinfo(const char *name, const char *serv, const struct addri
 
 static void socketsrv_thread(void *arg)
 {
-	struct addrinfo hint = { 0 };
-	unsigned respid;
-	char *node, *serv;
+	unsigned long respid;
 	size_t sz;
 	msg_t msg;
 	uint32_t port;
 	int err, sock;
+#if LWIP_DNS
+	struct addrinfo hint = { 0 };
+	char *node, *serv;
+#endif
 
 	port = (unsigned)arg;
 


### PR DESCRIPTION
New version hw/fw of modem changed their behavior – instead of hanging on AT_CONNECT_CMD now it returns error immediately if cannot do a connection yet. 

I added retrying connect command if doesn't timeouted. 

Also fixed some simple warnings 