### PR TITLE
Add armv7m7-imxrt106x LwIP target with device-to-device IoT communication driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for phoenix-rtos-lwip
 #
-# Copyright 2019-2020 Phoenix Systems
+# Copyright 2019-2021 Phoenix Systems
 #
 # %LICENSE%
 #
@@ -35,6 +35,7 @@ PORT_OBJS := $(patsubst %.c,$(PREFIX_O)%.o,$(PORT_SRCS))
 DRIVERS_SRCS := netif-driver.c
 DRIVERS_SRCS_UTIL := bdring.c pktmem.c physmmap.c res-create.c
 DRIVERS_SRCS_pppos := pppos.c
+DRIVERS_SRCS_pppou := pppou.c
 DRIVERS_SRCS_tuntap := tuntap.c
 -include _targets/Makefile.$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)
 DRIVERS_SRCS += $(foreach driver,$(NET_DRIVERS),$(if $(filter $(driver),$(NET_DRIVERS_SUPPORTED)),\

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MAKEFLAGS += --no-print-directory
 
 TARGET ?= ia32-generic
 #TARGET ?= armv7m4-stm32l4x6
+#TARGET ?= armv7m7-imxrt106x
 #TARGET ?= armv7a7-imx6ull
 
 include ../phoenix-rtos-build/Makefile.common

--- a/_targets/Makefile.armv7m7-imxrt106x
+++ b/_targets/Makefile.armv7m7-imxrt106x
@@ -1,0 +1,10 @@
+#
+# Makefile for Phoenix-RTOS 3 LwIP
+#
+# iMX RT1064 target
+#
+# Copyright 2021 Phoenix Systems
+#
+
+NET_DRIVERS_SUPPORTED := pppou
+NET_DRIVERS ?= $(NET_DRIVERS_SUPPORTED)

--- a/drivers/pppou.c
+++ b/drivers/pppou.c
@@ -1,0 +1,770 @@
+/*
+ * Phoenix-RTOS --- networking stack
+ *
+ * PPP over Serial driver
+ *
+ * Copyright 2018 Phoenix Systems
+ * Author: Marek Białowąs
+ *
+ * %LICENSE%
+ */
+
+#include "netif-driver.h"
+
+#include <netif/ppp/pppapi.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <unistd.h>
+#include <strings.h>
+#include <sys/threads.h>
+#include <sys/msg.h>
+#include <syslog.h>
+
+#include <pppos_modem.h>
+
+enum {
+	CONN_STATE_DISCONNECTING,
+	CONN_STATE_DISCONNECTED,
+	CONN_STATE_CONNECTING,
+	CONN_STATE_CONNECTED,
+};
+
+typedef struct
+{
+	struct netif *netif;
+	ppp_pcb* ppp;
+
+	const char *serialdev_fn;
+	const char *serialat_fn;
+#if PPPOS_USE_CONFIG_FILE
+	const char *config_path;
+	char apn[64];
+#endif
+	int fd;
+
+	volatile int want_connected;
+	volatile int conn_state;
+	handle_t lock, cond;
+
+	uint32_t main_loop_stack[4096];
+} pppos_priv_t;
+
+#define COL_RED     "\033[1;31m"
+#define COL_CYAN    "\033[1;36m"
+#define COL_YELLOW  "\033[1;33m"
+#define COL_NORMAL  "\033[0m"
+
+#if 0
+#define log_debug(fmt, ...)     do { if (1) pppos_printf(state, fmt, ##__VA_ARGS__); } while (0)
+#define log_at(fmt, ...)     	do { if (1) pppos_printf(state, COL_CYAN fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_info(fmt, ...)      do { if (1) pppos_printf(state, COL_CYAN fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_warn(fmt, ...)      do { if (1) pppos_printf(state, COL_YELLOW fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_error(fmt, ...)     do { if (1) pppos_printf(state, COL_RED  fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
+
+static void pppos_printf(pppos_priv_t *state, const char *format, ...)
+{
+	char buf[256];
+	va_list arg;
+
+	va_start(arg, format);
+	vsnprintf(buf, sizeof(buf), format, arg);
+	va_end(arg);
+
+	printf("lwip: ppp@%s %s\n", state->serialdev_fn, buf);
+}
+#else
+
+#define log_debug(fmt, ...) syslog(LOG_DEBUG, fmt, ##__VA_ARGS__)
+#define log_at(fmt, ...)    syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+#define log_info(fmt, ...)  syslog(LOG_INFO, fmt, ##__VA_ARGS__)
+#define log_warn(fmt, ...)  syslog(LOG_WARNING, fmt, ##__VA_ARGS__)
+#define log_error(fmt, ...) syslog(LOG_ERR, fmt, ##__VA_ARGS__)
+
+#endif
+
+#define PPPOS_READ_AT_TIMEOUT_STEP_MS 		5
+#define PPPOS_READ_DATA_TIMEOUT_STEP_MS 	10
+
+#define PPPOS_TRYOPEN_SERIALDEV_SEC 		3
+#define PPPOS_CONNECT_RETRY_SEC 		5
+#define PPPOS_CONNECT_CMD_RETRY_MS		500
+
+/****** serial handling ******/
+
+static void serial_close(int fd)
+{
+	log_info("close()");
+
+	if (fd >= 0)
+		close(fd);
+
+//	state->fd = -1;
+	// NOTE: set DISCONNECTED in status callback
+	// state->conn_state = CONN_STATE_DISCONNECTED;
+}
+
+static void serial_set_non_blocking(int fd)
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
+		log_error("%s() : fcntl(%d, O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
+}
+
+#if 0
+static void serial_set_blocking(int fd)
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
+		log_error("%s() : fcntl(%d, ~O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
+}
+#endif
+
+#define WRITE_MAX_RETRIES 2
+static int serial_write(int fd, const u8_t* data, u32_t len)
+{
+	int off = 0;
+	int retries = 0;
+	while (off < len) {
+		int to_write = len - off;
+		int res = write(fd, data + off, to_write);
+
+		if (res < 0) {
+			if (errno == EINTR) {
+				//log_sys_err("%s() : write(%d)\n", __func__, to_write);
+				usleep(5*1000);
+				continue;
+			}
+			if (errno == EWOULDBLOCK) {
+				goto retry;
+			}
+			log_error("%s() : write(%d) = %d (%s)", __func__, to_write, errno, strerror(errno));
+			return -1;
+		}
+
+		// at least partial-write succeeded
+		off += res;
+		retries = 0;
+		continue;
+
+retry:
+		if (retries >= WRITE_MAX_RETRIES) {
+			return off;
+		} else {
+			retries += 1;
+			usleep(5*1000);
+			continue;
+		}
+	}
+
+	return off;
+}
+
+/****** AT commands support ******/
+
+// AT commands result codes
+enum {
+	AT_RESULT_OK,
+	AT_RESULT_CONNECT,
+	AT_RESULT_RING,
+	AT_RESULT_NO_CARRIER,
+	AT_RESULT_ERROR,
+	AT_RESULT_NO_ANSWER
+};
+
+static const char* at_result_codes[] = { "OK", "CONNECT", "RING", "NO CARRIER", "ERROR", "NO ANSWER", NULL };
+static int at_result_codes_len = sizeof(at_result_codes) / sizeof(at_result_codes[0]);
+
+static int at_check_result(const char* buf)
+{
+	int res = 0;
+	char* result;
+
+	while (at_result_codes[res]) {
+		if ((result = strstr(buf, at_result_codes[res])) != NULL) {
+			return res;
+		}
+		res += 1;
+	}
+
+	return -1;
+}
+
+static const char * at_result_to_str(int res) {
+	if (res < 0 || res >= at_result_codes_len)
+		return "!INVALID!";
+
+	return at_result_codes[res];
+}
+
+
+static int at_send_cmd_res(int fd, const char* cmd, int timeout_ms, char *rx_buf, int rx_bufsize)
+{
+	int max_len = rx_bufsize - 1;
+
+	if (fd < 0) {
+		log_error("%s: invalid file descriptor!", __func__);
+		return ERR_ARG;
+	}
+
+	log_at("AT Tx: [%s]", cmd);
+	serial_write(fd, (u8_t*)cmd, strlen(cmd));
+
+	// wait for result with optional response text
+	int off = 0;
+	while (off < max_len) {
+		int len = read(fd, rx_buf + off, max_len - off);
+		if (len < 0) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EWOULDBLOCK)
+				goto retry;
+			log_error("%s() : read(%d) = %d (%d -> %s)", __func__, max_len - off, len, errno, strerror(errno));
+			serial_close(fd);
+			return -1;
+		} else if (len == 0) {
+			log_error("%s() : read(%d) = %d (%d -> %s)", __func__, max_len - off, len, errno, strerror(errno));
+			serial_close(fd);
+			return -1;
+		} else {
+			rx_buf[off + len + 1] = '\0';
+
+			int res = at_check_result(rx_buf);
+			off += len;
+
+			if (res >= 0) {
+#if 1
+				// remove newlines for better result printing
+				for (int i = 0; i < off; ++i)
+					if (rx_buf[i] == '\n' || rx_buf[i] == '\r')
+						rx_buf[i] = '.';
+#endif
+				log_at("AT Rx: result=[%s] data=[%s]", at_result_to_str(res), rx_buf);
+				return res;
+			}
+
+		}
+		continue;
+
+retry:
+		usleep(PPPOS_READ_AT_TIMEOUT_STEP_MS * 1000);
+		if (timeout_ms >= 0) {
+			timeout_ms -= PPPOS_READ_AT_TIMEOUT_STEP_MS;
+			if (timeout_ms <= 0) {
+				log_warn("%s: timeouted while waiting for response!", __func__);
+				return -1;
+			}
+		}
+	}
+
+	log_warn("%s: AT response too large", __func__);
+	return -1;
+}
+
+
+static int at_send_cmd(int fd, const char* cmd, int timeout_ms)
+{
+	char rx_buf[512];
+	return at_send_cmd_res(fd, cmd, timeout_ms, rx_buf, sizeof(rx_buf));
+}
+
+
+// NOTE: this only disconnects the AT modem from the data connection
+// Currently only used in initialisation
+#if PPPOS_DISCONNECT_ON_INIT
+static int at_disconnect(int fd) {
+	// TODO: do it better (finite retries? broken?)
+	int res;
+	int retries = 3;
+	do {
+		serial_write(fd, (u8_t*) "+++", 3);	// ATS2 - escape char (default '+')
+		usleep(1000 * 1000);		// ATS12 - escape prompt delay (default: 1s)
+		res = at_send_cmd(fd, "ATH\r\n", 3000);
+	} while (res != AT_RESULT_OK && --retries);
+
+	return res;
+}
+#endif
+
+static int at_is_responding(int fd, int timeout_ms)
+{
+	int res;
+	int retry = 5;
+
+	while ((res = at_send_cmd(fd, "AT\r\n", timeout_ms)) != AT_RESULT_OK && retry--);
+
+	if (res != AT_RESULT_OK) {
+		log_warn("modem not responding, res=%d", res);
+		return 0;
+	}
+
+	return 1;
+}
+
+
+/****** PPPoS support functions ******/
+
+static u32_t pppos_output_cb(ppp_pcb *pcb, u8_t *data, u32_t len, void *ctx)
+{
+	pppos_priv_t* state = (pppos_priv_t*) ctx;
+
+	int res = serial_write(state->fd, data, len);
+	//log_debug("%s : write(%d) = %d", __func__, len, res);
+	if (res < 0 && errno != EINTR && errno != EWOULDBLOCK) {
+		log_error("%s() : write(%d) = %d (%d -> %s)", __func__, len, res, errno, strerror(errno));
+		serial_close(state->fd);
+		state->fd = -1;
+		return 0;
+	}
+
+	return res;
+}
+
+static void pppos_link_status_cb(ppp_pcb *pcb, int err_code, void *ctx)
+{
+	struct netif *pppif = ppp_netif(pcb);
+	pppos_priv_t* state = (pppos_priv_t*) ctx;
+	mutexLock(state->lock);
+
+	switch(err_code) {
+	case PPPERR_NONE:               /* No error. */
+		{
+			state->conn_state = CONN_STATE_CONNECTED;
+
+			log_info("ppp_link_status_cb: PPPERR_NONE");
+#if LWIP_IPV4
+			log_info("   our_ip4addr = %s", ip4addr_ntoa(netif_ip4_addr(pppif)));
+			log_info("   his_ipaddr  = %s", ip4addr_ntoa(netif_ip4_gw(pppif)));
+			log_info("   netmask     = %s", ip4addr_ntoa(netif_ip4_netmask(pppif)));
+#endif /* LWIP_IPV4 */
+#if LWIP_IPV6
+			log_info("   our_ip6addr = %s", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
+#endif /* LWIP_IPV6 */
+
+#if PPP_IPV6_SUPPORT
+			log_info("   our6_ipaddr = %s\n\r", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
+#endif /* PPP_IPV6_SUPPORT */
+		}
+		break;
+
+	case PPPERR_PARAM:             /* Invalid parameter. */
+		log_info("ppp_link_status_cb: PPPERR_PARAM");
+		// TODO: error?
+		break;
+
+	case PPPERR_OPEN:              /* Unable to open PPP session. */
+		log_info("ppp_link_status_cb: PPPERR_OPEN");
+		break;
+
+	case PPPERR_DEVICE:            /* Invalid I/O device for PPP. */
+		log_info("ppp_link_status_cb: PPPERR_DEVICE");
+		serial_close(state->fd);
+		state->fd = -1;
+		break;
+
+	case PPPERR_ALLOC:             /* Unable to allocate resources. */
+		log_info("ppp_link_status_cb: PPPERR_ALLOC");
+		//TODO: broken
+		break;
+
+	case PPPERR_USER:              /* User interrupt. */
+		log_info("ppp_link_status_cb: PPPERR_USER");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_CONNECT:           /* Connection lost. */
+		log_info("ppp_link_status_cb: PPPERR_CONNECT");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_AUTHFAIL:          /* Failed authentication challenge. */
+		log_info("ppp_link_status_cb: PPPERR_AUTHFAIL");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_PROTOCOL:          /* Failed to meet protocol. */
+		log_info("ppp_link_status_cb: PPPERR_PROTOCOL");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_PEERDEAD:          /* Connection timeout. */
+		log_info("ppp_link_status_cb: PPPERR_PEERDEAD");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_IDLETIMEOUT:       /* Idle Timeout. */
+		log_info("ppp_link_status_cb: PPPERR_IDLETIMEOUT");
+		break;
+
+	case PPPERR_CONNECTTIME:       /* Max connect time reached */
+		log_info("ppp_link_status_cb: PPPERR_CONNECTTIME");
+		state->conn_state = CONN_STATE_DISCONNECTED;
+		break;
+
+	case PPPERR_LOOPBACK:          /* Loopback detected */
+		log_info("ppp_link_status_cb: PPPERR_LOOPBACK");
+		break;
+
+	default:
+		log_info("ppp_link_status_cb: unknown error code: %d", err_code);
+		break;
+	}
+
+	log_info("ppp_link_status_cb out");
+	mutexUnlock(state->lock);
+	condSignal(state->cond);
+}
+
+static void pppos_do_rx(pppos_priv_t* state)
+{
+	int len;
+	u8_t buffer[1024];
+
+	while (state->conn_state != CONN_STATE_DISCONNECTED
+			&& state->conn_state != CONN_STATE_DISCONNECTING) {
+		len = read(state->fd, buffer, sizeof(buffer));
+		if (len > 0) {
+			/* Pass received raw characters from PPPoS to be decoded through lwIP
+			* TCPIP thread using the TCPIP API. This is thread safe in all cases
+			* but you should avoid passing data byte after byte. */
+			//log_debug("%s : read() = %d", __func__, len);
+			pppos_input_tcpip(state->ppp, buffer, len);
+		} else {
+			if (len < 0 && errno != EINTR && errno != EWOULDBLOCK) {
+				log_error("%s() : read(%d) = %d (%d -> %s)", __func__, sizeof(buffer), len, errno, strerror(errno));
+				serial_close(state->fd);
+				state->fd = -1;
+				return;
+			}
+			usleep(PPPOS_READ_DATA_TIMEOUT_STEP_MS * 1000);
+		}
+	}
+
+	log_warn("%s: exiting\n", __func__);
+}
+
+
+static void pppos_mainLoop(void* _state)
+{
+	pppos_priv_t* state = (pppos_priv_t*) _state;
+	int res;
+	int retries;
+
+	int running = 1;
+
+	while (running) {
+		mutexLock(state->lock);
+		while (!state->want_connected) {
+			condWait(state->cond, state->lock, 0);
+		}
+		mutexUnlock(state->lock);
+
+		/* Wait for the serial device */
+		if (state->fd < 0)  {
+			while ((state->fd = open(state->serialdev_fn, O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0)
+				sleep(PPPOS_TRYOPEN_SERIALDEV_SEC);
+
+			log_info("open success!");
+		}
+
+		serial_set_non_blocking(state->fd);
+#if PPPOS_DISCONNECT_ON_INIT
+		if (at_disconnect(state->fd) != AT_RESULT_OK)
+			goto fail;
+#endif
+
+#if PPPOS_USE_CONFIG_FILE
+		mutexLock(state->lock);
+		while (!state->apn[0])
+			condWait(state->cond, state->lock, 0);
+		mutexUnlock(state->lock);
+#endif
+
+		if (!at_is_responding(state->fd, 1000)) {
+			goto fail;
+		}
+
+		const char** at_cmd = at_init_cmds;
+		while (*at_cmd) {
+			if ((res = at_send_cmd(state->fd, *at_cmd, AT_INIT_CMDS_TIMEOUT_MS)) != AT_RESULT_OK) {
+				log_warn("failed to initialize modem (cmd=%s), res=%d, retrying", *at_cmd, res);
+				goto fail;
+			}
+
+			at_cmd += 1;
+		}
+
+#if PPPOS_USE_CONFIG_FILE
+		{ /* Configure APN */
+			char at_set_apn[256];
+			if (snprintf(at_set_apn, sizeof(at_set_apn), "AT+CGDCONT=1,\"IP\",\"%s\"\r\n", state->apn) >= sizeof(at_set_apn)) {
+				log_error("APN name too long");
+				goto fail;
+			}
+
+			if ((res = at_send_cmd(state->fd, at_set_apn, 3000)) != AT_RESULT_OK) {
+				log_warn("failed to set APN, retrying");
+				goto fail;
+			}
+		}
+#endif
+
+		/* Some modems hanging on AT_CONNECT_CMD, some returning error when not ready yet.
+		 * Retrying until receive AT_RESULT_CONNECT or standard timeout is reached (res < 0)
+		 */
+		retries = AT_CONNECT_CMD_TIMEOUT_MS / PPPOS_CONNECT_CMD_RETRY_MS;
+		while ((res = at_send_cmd(state->fd, AT_CONNECT_CMD, AT_CONNECT_CMD_TIMEOUT_MS)) != AT_RESULT_CONNECT) {
+			if (retries-- <= 0 || res < 0) {
+				log_warn("failed to dial PPP, res=%d, retrying", res);
+				goto fail;
+			}
+			usleep(PPPOS_CONNECT_CMD_RETRY_MS * 1000);
+		}
+
+		log_debug("ppp_connect");
+		state->conn_state = CONN_STATE_CONNECTING;
+		pppapi_connect(state->ppp, 0);
+
+		//serial_set_blocking(state);
+		log_debug("receiving");
+		pppos_do_rx(state);
+
+		log_debug("pppapi_close");
+		pppapi_close(state->ppp, 0);
+
+		mutexLock(state->lock);
+		log_debug("waiting for close to complete");
+		while (state->conn_state != CONN_STATE_DISCONNECTED) {
+			condWait(state->cond, state->lock, 0);
+			log_debug("still waiting for close to complete");
+		}
+		mutexUnlock(state->lock);
+
+		log_debug("connection closed");
+
+fail:
+		serial_close(state->fd);
+		state->fd = -1;
+
+		sleep(PPPOS_CONNECT_RETRY_SEC);
+	}
+
+	// NOTE: never tested
+	if (state->ppp) {
+		pppapi_close(state->ppp, 0);
+		pppapi_free(state->ppp);
+	}
+
+	endthread();
+}
+
+
+static int pppos_netifUp(pppos_priv_t *state)
+{
+#if PPPOS_USE_CONFIG_FILE
+	char lcfg[256] = { 0 };
+	int line = 0;
+	FILE *fcfg = fopen(state->config_path, "r");
+	char *cfgval;
+	char *eq;
+
+	if (fcfg == NULL)
+		return 1;
+
+	if (state->apn[0]) {
+		fclose(fcfg);
+		return 0;
+	}
+
+	mutexLock(state->lock);
+	while (fgets(lcfg, sizeof(lcfg), fcfg) != NULL) {
+		line++;
+		if (lcfg[0] == '#')
+			continue;
+
+		if ((eq = strchr(lcfg, '=')) == NULL) {
+			log_error("[line %d] invalid format - missing '='", line);
+			continue;
+		}
+
+		lcfg[strcspn(lcfg, "\r\n")] = 0;
+
+		*eq = 0;
+		cfgval = eq + 1;
+
+		if (cfgval[0] == '"' || cfgval[0] == '\'') {
+			cfgval++;
+			cfgval[strlen(cfgval) - 1] = 0;
+		}
+
+		if (!strcasecmp(lcfg, "apn"))
+			strncpy(state->apn, cfgval, sizeof(state->apn) - 1);
+		else
+			log_warn("[line %d] unsupported option: %s (val: %s)", line, lcfg, cfgval);
+	}
+
+	fclose(fcfg);
+#else
+	mutexLock(state->lock);
+#endif
+	state->want_connected = 1;
+	condSignal(state->cond);
+	mutexUnlock(state->lock);
+
+	return 0;
+}
+
+
+static int pppos_netifDown(pppos_priv_t *state)
+{
+	/* Unconditional use of pppapi_close() in the status callback
+	can (and will) cause recursive firing of the callback */
+
+	mutexLock(state->lock);
+#if PPPOS_USE_CONFIG_FILE
+	if (state->apn[0]) {
+		state->apn[0] = 0;
+		state->conn_state = CONN_STATE_DISCONNECTING;
+	}
+#else
+	state->conn_state = CONN_STATE_DISCONNECTING;
+#endif
+	state->want_connected = 0;
+	mutexUnlock(state->lock);
+
+	return 0;
+}
+
+
+static pppos_priv_t *pppos_netifState(struct netif *netif)
+{
+	struct netif_alloc *s = (void *)netif;
+	pppos_priv_t *state = (void *) ((char *)s + ((sizeof(*s) + (_Alignof(pppos_priv_t) - 1)) & ~(_Alignof(pppos_priv_t) - 1)));
+	return state;
+}
+
+
+static void pppos_statusCallback(struct netif *netif)
+{
+	pppos_priv_t *state = pppos_netifState(netif);
+
+	if (netif->flags & NETIF_FLAG_UP) {
+		if (pppos_netifUp(state))
+			netif->flags &= ~NETIF_FLAG_UP;
+	} else if (pppos_netifDown(state)) {
+		netif->flags |= NETIF_FLAG_UP;
+	}
+}
+
+static int pppos_netifInit(struct netif *netif, char *cfg)
+{
+	pppos_priv_t* state;
+
+
+	// NOTE: netif->state cannot be used to keep our private state as it is used by LWiP PPP implementation, pass it as *ctx to callbacks
+	state = netif->state;
+	netif->state = NULL;
+
+	memset(state, 0, sizeof(pppos_priv_t));
+	state->netif = netif;
+	state->serialdev_fn = cfg;
+
+	while (*cfg && *cfg != ':')
+		++cfg;
+
+	if (*cfg != ':') {
+		log_error("APN is not configured");
+		return ERR_ARG;
+	}
+
+	*cfg = 0;
+	cfg++;
+
+#if PPPOS_USE_CONFIG_FILE
+	state->config_path = cfg;
+#endif
+
+	while (*cfg && *cfg != ':')
+		++cfg;
+
+	if (*cfg == ':') {
+		*cfg = 0;
+		cfg++;
+		state->serialat_fn = cfg;
+	}
+	else {
+		state->serialat_fn = "/dev/ttyacm1";
+	}
+
+	state->fd = -1;
+
+	mutexCreate(&state->lock);
+	condCreate(&state->cond);
+
+	netif->name[0] = 'p';
+	netif->name[1] = 'p';
+
+	if (!cfg)
+		return ERR_ARG;
+
+	if (!state->ppp) {
+		state->ppp = pppapi_pppos_create(state->netif, pppos_output_cb, pppos_link_status_cb, state);
+
+		if (!state->ppp) {
+			log_error("could not create PPP control interface");
+			return ERR_IF ; // TODO: maybe permanent broken state?
+		}
+		netif->flags &= ~NETIF_FLAG_UP;
+		ppp_set_netif_statuscallback(state->ppp, pppos_statusCallback);
+	}
+
+	beginthread(pppos_mainLoop, 4, (void *)state->main_loop_stack, sizeof(state->main_loop_stack), state);
+
+	return ERR_OK;
+}
+
+
+const char *pppos_media(struct netif *netif)
+{
+	pppos_priv_t *state = pppos_netifState(netif);
+	int fd = open(state->serialat_fn, O_RDWR | O_NONBLOCK);
+	char buffer[256];
+	int result;
+
+	if (fd < 0)
+		return "error/open";
+
+	if ((result = at_send_cmd_res(fd, "AT+COPS?\r\n", 300, buffer, sizeof(buffer))) != AT_RESULT_OK)
+		return "error/read";
+
+	close(fd);
+
+	if (strstr(buffer, "\",0") != NULL)
+		return "2G";
+	else if (strstr(buffer, "\",2") != NULL)
+		return "3G";
+	else if (strstr(buffer, "\",7") != NULL || strstr(buffer, "\",9") != NULL)
+		return "4G";
+	else
+		return "unrecognized";
+}
+
+
+static netif_driver_t pppos_drv = {
+	.init = pppos_netifInit,
+	.state_sz = sizeof(pppos_priv_t),
+	.state_align = _Alignof(pppos_priv_t),
+	.name = "pppos",
+	.media = pppos_media,
+};
+
+
+__constructor__(1000)
+void register_driver_pppos(void)
+{
+	register_netif_driver(&pppos_drv);
+}

--- a/drivers/pppou.c
+++ b/drivers/pppou.c
@@ -1,10 +1,10 @@
 /*
  * Phoenix-RTOS --- networking stack
  *
- * PPP over Serial driver
+ * PPP over Serial (null modem) driver
  *
- * Copyright 2018 Phoenix Systems
- * Author: Marek Białowąs
+ * Copyright 2018, 2021 Phoenix Systems
+ * Author: Marek Białowąs, Gerard Świderski
  *
  * %LICENSE%
  */
@@ -14,7 +14,6 @@
 #include <netif/ppp/pppapi.h>
 
 #include <errno.h>
-#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -23,15 +22,33 @@
 #include <strings.h>
 #include <sys/threads.h>
 #include <sys/msg.h>
+#include <sys/stat.h>
+#include <termios.h>
 #include <syslog.h>
 
-#include <pppos_modem.h>
+/*
+ *  Setup full-duplex connection between host and device with RS232, uart USB-TTL adapter, direct TTL-TTL, bluetooth-UART/TTL, etc.
+ *
+ *  1. On device (phoenix-rtos) side, addr=10.0.0.2, use:
+ *     lwip pppou:/dev/uart3:<speed>:up
+ *     (speed defaults to 115200 if ommited, 'up' brings interface up after setup, also optional)
+ *
+ *  2. On host (linux, bsd) side, addr=10.0.0.1, use e.g.:
+ *     pppd /dev/ttyUSB0 <speed> 10.0.0.1:10.0.0.2 lock local nodetach noauth debug dump nocrtscts nodefaultroute maxfail 0 holdoff 1
+ *
+ *  Replace <speed> with any of the baud rate supported by the system, e.g. 9600, 115200, 230400 or 460800.
+ */
 
-enum {
+
+enum conn_state_e {
 	CONN_STATE_DISCONNECTING,
 	CONN_STATE_DISCONNECTED,
 	CONN_STATE_CONNECTING,
 	CONN_STATE_CONNECTED,
+};
+
+enum cfg_flag_e {
+	CFG_FLAG_DEFAULT_UP = 0x01
 };
 
 typedef struct
@@ -39,45 +56,20 @@ typedef struct
 	struct netif *netif;
 	ppp_pcb* ppp;
 
-	const char *serialdev_fn;
-	const char *serialat_fn;
-#if PPPOS_USE_CONFIG_FILE
-	const char *config_path;
-	char apn[64];
-#endif
+	const char *serial_dev;
+	speed_t serial_speed;
 	int fd;
 
+	volatile int thread_running;
 	volatile int want_connected;
 	volatile int conn_state;
 	handle_t lock, cond;
 
-	uint32_t main_loop_stack[4096];
-} pppos_priv_t;
+	unsigned char main_loop_stack[4096] __attribute__((aligned(8)));
+} pppou_priv_t;
 
-#define COL_RED     "\033[1;31m"
-#define COL_CYAN    "\033[1;36m"
-#define COL_YELLOW  "\033[1;33m"
-#define COL_NORMAL  "\033[0m"
 
-#if 0
-#define log_debug(fmt, ...)     do { if (1) pppos_printf(state, fmt, ##__VA_ARGS__); } while (0)
-#define log_at(fmt, ...)     	do { if (1) pppos_printf(state, COL_CYAN fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
-#define log_info(fmt, ...)      do { if (1) pppos_printf(state, COL_CYAN fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
-#define log_warn(fmt, ...)      do { if (1) pppos_printf(state, COL_YELLOW fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
-#define log_error(fmt, ...)     do { if (1) pppos_printf(state, COL_RED  fmt COL_NORMAL, ##__VA_ARGS__); } while (0)
-
-static void pppos_printf(pppos_priv_t *state, const char *format, ...)
-{
-	char buf[256];
-	va_list arg;
-
-	va_start(arg, format);
-	vsnprintf(buf, sizeof(buf), format, arg);
-	va_end(arg);
-
-	printf("lwip: ppp@%s %s\n", state->serialdev_fn, buf);
-}
-#else
+#ifdef LOG_ENABLED
 
 #define log_debug(fmt, ...) syslog(LOG_DEBUG, fmt, ##__VA_ARGS__)
 #define log_at(fmt, ...)    syslog(LOG_INFO, fmt, ##__VA_ARGS__)
@@ -85,16 +77,110 @@ static void pppos_printf(pppos_priv_t *state, const char *format, ...)
 #define log_warn(fmt, ...)  syslog(LOG_WARNING, fmt, ##__VA_ARGS__)
 #define log_error(fmt, ...) syslog(LOG_ERR, fmt, ##__VA_ARGS__)
 
+#else
+
+#define log_debug(fmt, ...)
+#define log_at(fmt, ...)
+#define log_info(fmt, ...)
+#define log_warn(fmt, ...)
+#define log_error(fmt, ...)
+
 #endif
 
-#define PPPOS_READ_AT_TIMEOUT_STEP_MS 		5
-#define PPPOS_READ_DATA_TIMEOUT_STEP_MS 	10
+#define PPPOU_READ_DATA_TIMEOUT_STEP_MS  10
 
-#define PPPOS_TRYOPEN_SERIALDEV_SEC 		3
-#define PPPOS_CONNECT_RETRY_SEC 		5
-#define PPPOS_CONNECT_CMD_RETRY_MS		500
+#define PPPOU_TRYOPEN_SERIALDEV_SEC      3
+#define PPPOU_CONNECT_RETRY_SEC          5
+
 
 /****** serial handling ******/
+
+
+struct serial_speed_s {
+	const char *str;
+	speed_t speed;
+};
+
+
+static int _speedcmp(const void *l, const void *r)
+{
+	return strcmp(((struct serial_speed_s *)l)->str, ((struct serial_speed_s *)r)->str);
+}
+
+
+static speed_t serial_speed_from_string(const char *str)
+{
+	/* table is lexically sorted by `str` */
+	static const struct serial_speed_s stab[] = {
+		{ "0", B0 },           { "110", B110 },       { "115200", B115200 },
+		{ "1200", B1200 },     { "134", B134 },       { "150", B150 },
+		{ "1800", B1800 },     { "19200", B19200 },   { "200", B200 },
+		{ "230400", B230400 }, { "2400", B2400 },     { "300", B300 },
+		{ "38400", B38400 },   { "460800", B460800 }, { "4800", B4800 },
+		{ "50", B50 },         { "57600", B57600 },   { "600", B600 },
+		{ "75", B75 },         { "9600", B9600 },
+	};
+
+	struct serial_speed_s *sptr;
+
+	if (str && (sptr = bsearch(&str, stab, sizeof(stab) / sizeof(stab[0]), sizeof(stab[0]), _speedcmp)))
+		return sptr->speed;
+
+	return -1;
+}
+
+
+static int serial_open(const char *devname, speed_t speed)
+{
+	oid_t oid;
+	int fd, ret, cnt;
+	struct termios tio;
+
+	if (!devname)
+		return -1;
+
+	/* try if uart is registered */
+	for (cnt = 0; (ret = lookup(devname, NULL, &oid)) < 0; cnt++) {
+		usleep(200 * 1000);
+		if (cnt > 3)
+			return ret;
+	}
+
+	if ((fd = open(devname, O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0)
+		return fd;
+
+	memset(&tio, 0, sizeof(tio));
+
+	if ((ret = tcgetattr(fd, &tio)) < 0)
+		goto on_error;
+
+	if ((ret = cfsetspeed(&tio, speed)) < 0)
+		goto on_error;
+
+	tio.c_cc[VTIME] = 0; /* no timeout */
+	tio.c_cc[VMIN] = 0;  /* polling */
+
+	/* libtty does not support yet: IXON|IXOFF|IXANY|PARMRK|INPCK|IGNPAR */
+	tio.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	tio.c_oflag &= ~OPOST;
+	tio.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	tio.c_cflag &= ~(CSIZE | CSTOPB);
+
+	tio.c_cflag |= CS8 | CREAD | CLOCAL;
+
+	if ((ret = tcflush(fd, TCIOFLUSH)) < 0)
+		goto on_error;
+
+	if ((ret = tcsetattr(fd, TCSANOW, &tio)) < 0)
+		goto on_error;
+
+	return fd;
+
+on_error:
+	close(fd);
+	return ret;
+}
+
 
 static void serial_close(int fd)
 {
@@ -102,30 +188,11 @@ static void serial_close(int fd)
 
 	if (fd >= 0)
 		close(fd);
-
-//	state->fd = -1;
-	// NOTE: set DISCONNECTED in status callback
-	// state->conn_state = CONN_STATE_DISCONNECTED;
 }
 
-static void serial_set_non_blocking(int fd)
-{
-	int flags = fcntl(fd, F_GETFL, 0);
-	if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
-		log_error("%s() : fcntl(%d, O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
-}
-
-#if 0
-static void serial_set_blocking(int fd)
-{
-	int flags = fcntl(fd, F_GETFL, 0);
-	if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
-		log_error("%s() : fcntl(%d, ~O_NONBLOCK) = (%d -> %s)", __func__, fd, errno, strerror(errno));
-}
-#endif
 
 #define WRITE_MAX_RETRIES 2
-static int serial_write(int fd, const u8_t* data, u32_t len)
+static int serial_write(int fd, const u8_t *data, u32_t len)
 {
 	int off = 0;
 	int retries = 0;
@@ -135,8 +202,8 @@ static int serial_write(int fd, const u8_t* data, u32_t len)
 
 		if (res < 0) {
 			if (errno == EINTR) {
-				//log_sys_err("%s() : write(%d)\n", __func__, to_write);
-				usleep(5*1000);
+				/* log_sys_err("%s() : write(%d)\n", __func__, to_write); */
+				usleep(5 * 1000);
 				continue;
 			}
 			if (errno == EWOULDBLOCK) {
@@ -146,7 +213,7 @@ static int serial_write(int fd, const u8_t* data, u32_t len)
 			return -1;
 		}
 
-		// at least partial-write succeeded
+		/* at least partial-write succeeded */
 		off += res;
 		retries = 0;
 		continue;
@@ -154,9 +221,10 @@ static int serial_write(int fd, const u8_t* data, u32_t len)
 retry:
 		if (retries >= WRITE_MAX_RETRIES) {
 			return off;
-		} else {
+		}
+		else {
 			retries += 1;
-			usleep(5*1000);
+			usleep(5 * 1000);
 			continue;
 		}
 	}
@@ -164,156 +232,17 @@ retry:
 	return off;
 }
 
-/****** AT commands support ******/
 
-// AT commands result codes
-enum {
-	AT_RESULT_OK,
-	AT_RESULT_CONNECT,
-	AT_RESULT_RING,
-	AT_RESULT_NO_CARRIER,
-	AT_RESULT_ERROR,
-	AT_RESULT_NO_ANSWER
-};
+/****** PPPoU support functions ******/
 
-static const char* at_result_codes[] = { "OK", "CONNECT", "RING", "NO CARRIER", "ERROR", "NO ANSWER", NULL };
-static int at_result_codes_len = sizeof(at_result_codes) / sizeof(at_result_codes[0]);
 
-static int at_check_result(const char* buf)
+static u32_t pppou_output_cb(ppp_pcb *pcb, u8_t *data, u32_t len, void *ctx)
 {
-	int res = 0;
-	char* result;
+	pppou_priv_t *state = (pppou_priv_t *)ctx;
 
-	while (at_result_codes[res]) {
-		if ((result = strstr(buf, at_result_codes[res])) != NULL) {
-			return res;
-		}
-		res += 1;
-	}
-
-	return -1;
-}
-
-static const char * at_result_to_str(int res) {
-	if (res < 0 || res >= at_result_codes_len)
-		return "!INVALID!";
-
-	return at_result_codes[res];
-}
-
-
-static int at_send_cmd_res(int fd, const char* cmd, int timeout_ms, char *rx_buf, int rx_bufsize)
-{
-	int max_len = rx_bufsize - 1;
-
-	if (fd < 0) {
-		log_error("%s: invalid file descriptor!", __func__);
-		return ERR_ARG;
-	}
-
-	log_at("AT Tx: [%s]", cmd);
-	serial_write(fd, (u8_t*)cmd, strlen(cmd));
-
-	// wait for result with optional response text
-	int off = 0;
-	while (off < max_len) {
-		int len = read(fd, rx_buf + off, max_len - off);
-		if (len < 0) {
-			if (errno == EINTR)
-				continue;
-			if (errno == EWOULDBLOCK)
-				goto retry;
-			log_error("%s() : read(%d) = %d (%d -> %s)", __func__, max_len - off, len, errno, strerror(errno));
-			serial_close(fd);
-			return -1;
-		} else if (len == 0) {
-			log_error("%s() : read(%d) = %d (%d -> %s)", __func__, max_len - off, len, errno, strerror(errno));
-			serial_close(fd);
-			return -1;
-		} else {
-			rx_buf[off + len + 1] = '\0';
-
-			int res = at_check_result(rx_buf);
-			off += len;
-
-			if (res >= 0) {
-#if 1
-				// remove newlines for better result printing
-				for (int i = 0; i < off; ++i)
-					if (rx_buf[i] == '\n' || rx_buf[i] == '\r')
-						rx_buf[i] = '.';
-#endif
-				log_at("AT Rx: result=[%s] data=[%s]", at_result_to_str(res), rx_buf);
-				return res;
-			}
-
-		}
-		continue;
-
-retry:
-		usleep(PPPOS_READ_AT_TIMEOUT_STEP_MS * 1000);
-		if (timeout_ms >= 0) {
-			timeout_ms -= PPPOS_READ_AT_TIMEOUT_STEP_MS;
-			if (timeout_ms <= 0) {
-				log_warn("%s: timeouted while waiting for response!", __func__);
-				return -1;
-			}
-		}
-	}
-
-	log_warn("%s: AT response too large", __func__);
-	return -1;
-}
-
-
-static int at_send_cmd(int fd, const char* cmd, int timeout_ms)
-{
-	char rx_buf[512];
-	return at_send_cmd_res(fd, cmd, timeout_ms, rx_buf, sizeof(rx_buf));
-}
-
-
-// NOTE: this only disconnects the AT modem from the data connection
-// Currently only used in initialisation
-#if PPPOS_DISCONNECT_ON_INIT
-static int at_disconnect(int fd) {
-	// TODO: do it better (finite retries? broken?)
-	int res;
-	int retries = 3;
-	do {
-		serial_write(fd, (u8_t*) "+++", 3);	// ATS2 - escape char (default '+')
-		usleep(1000 * 1000);		// ATS12 - escape prompt delay (default: 1s)
-		res = at_send_cmd(fd, "ATH\r\n", 3000);
-	} while (res != AT_RESULT_OK && --retries);
-
-	return res;
-}
-#endif
-
-static int at_is_responding(int fd, int timeout_ms)
-{
-	int res;
-	int retry = 5;
-
-	while ((res = at_send_cmd(fd, "AT\r\n", timeout_ms)) != AT_RESULT_OK && retry--);
-
-	if (res != AT_RESULT_OK) {
-		log_warn("modem not responding, res=%d", res);
-		return 0;
-	}
-
-	return 1;
-}
-
-
-/****** PPPoS support functions ******/
-
-static u32_t pppos_output_cb(ppp_pcb *pcb, u8_t *data, u32_t len, void *ctx)
-{
-	pppos_priv_t* state = (pppos_priv_t*) ctx;
-
+	log_debug("%s : write(%d)", __func__, len);
 	int res = serial_write(state->fd, data, len);
-	//log_debug("%s : write(%d) = %d", __func__, len, res);
+	/* log_debug("%s : write(%d) = %d", __func__, len, res); */
 	if (res < 0 && errno != EINTR && errno != EWOULDBLOCK) {
 		log_error("%s() : write(%d) = %d (%d -> %s)", __func__, len, res, errno, strerror(errno));
 		serial_close(state->fd);
@@ -324,94 +253,99 @@ static u32_t pppos_output_cb(ppp_pcb *pcb, u8_t *data, u32_t len, void *ctx)
 	return res;
 }
 
-static void pppos_link_status_cb(ppp_pcb *pcb, int err_code, void *ctx)
+
+static void pppou_link_status_cb(ppp_pcb *pcb, int err_code, void *ctx)
 {
+#ifdef LOG_ENABLED
 	struct netif *pppif = ppp_netif(pcb);
-	pppos_priv_t* state = (pppos_priv_t*) ctx;
+#endif
+
+	pppou_priv_t *state = (pppou_priv_t *)ctx;
+	log_debug("%s : status", __func__);
 	mutexLock(state->lock);
 
 	switch(err_code) {
-	case PPPERR_NONE:               /* No error. */
-		{
-			state->conn_state = CONN_STATE_CONNECTED;
+		case PPPERR_NONE:               /* No error. */
+			{
+				state->conn_state = CONN_STATE_CONNECTED;
 
-			log_info("ppp_link_status_cb: PPPERR_NONE");
+				log_info("ppp_link_status_cb: PPPERR_NONE");
 #if LWIP_IPV4
-			log_info("   our_ip4addr = %s", ip4addr_ntoa(netif_ip4_addr(pppif)));
-			log_info("   his_ipaddr  = %s", ip4addr_ntoa(netif_ip4_gw(pppif)));
-			log_info("   netmask     = %s", ip4addr_ntoa(netif_ip4_netmask(pppif)));
+				log_info("   our_ip4addr = %s", ip4addr_ntoa(netif_ip4_addr(pppif)));
+				log_info("   his_ip4addr = %s", ip4addr_ntoa(netif_ip4_gw(pppif)));
+				log_info("   netmask     = %s", ip4addr_ntoa(netif_ip4_netmask(pppif)));
 #endif /* LWIP_IPV4 */
 #if LWIP_IPV6
-			log_info("   our_ip6addr = %s", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
+				log_info("   our_ip6addr = %s", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
 #endif /* LWIP_IPV6 */
 
 #if PPP_IPV6_SUPPORT
-			log_info("   our6_ipaddr = %s\n\r", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
+				log_info("   our6_ipaddr = %s\n\r", ip6addr_ntoa(netif_ip6_addr(pppif, 0)));
 #endif /* PPP_IPV6_SUPPORT */
-		}
-		break;
+			}
+			break;
 
-	case PPPERR_PARAM:             /* Invalid parameter. */
-		log_info("ppp_link_status_cb: PPPERR_PARAM");
-		// TODO: error?
-		break;
+		case PPPERR_PARAM:             /* Invalid parameter. */
+			log_info("ppp_link_status_cb: PPPERR_PARAM");
+			/* TODO: error? */
+			break;
 
-	case PPPERR_OPEN:              /* Unable to open PPP session. */
-		log_info("ppp_link_status_cb: PPPERR_OPEN");
-		break;
+		case PPPERR_OPEN:              /* Unable to open PPP session. */
+			log_info("ppp_link_status_cb: PPPERR_OPEN");
+			break;
 
-	case PPPERR_DEVICE:            /* Invalid I/O device for PPP. */
-		log_info("ppp_link_status_cb: PPPERR_DEVICE");
-		serial_close(state->fd);
-		state->fd = -1;
-		break;
+		case PPPERR_DEVICE:            /* Invalid I/O device for PPP. */
+			log_info("ppp_link_status_cb: PPPERR_DEVICE");
+			serial_close(state->fd);
+			state->fd = -1;
+			break;
 
-	case PPPERR_ALLOC:             /* Unable to allocate resources. */
-		log_info("ppp_link_status_cb: PPPERR_ALLOC");
-		//TODO: broken
-		break;
+		case PPPERR_ALLOC:             /* Unable to allocate resources. */
+			log_info("ppp_link_status_cb: PPPERR_ALLOC");
+			/* TODO: broken */
+			break;
 
-	case PPPERR_USER:              /* User interrupt. */
-		log_info("ppp_link_status_cb: PPPERR_USER");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_USER:              /* User interrupt. */
+			log_info("ppp_link_status_cb: PPPERR_USER");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_CONNECT:           /* Connection lost. */
-		log_info("ppp_link_status_cb: PPPERR_CONNECT");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_CONNECT:           /* Connection lost. */
+			log_info("ppp_link_status_cb: PPPERR_CONNECT");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_AUTHFAIL:          /* Failed authentication challenge. */
-		log_info("ppp_link_status_cb: PPPERR_AUTHFAIL");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_AUTHFAIL:          /* Failed authentication challenge. */
+			log_info("ppp_link_status_cb: PPPERR_AUTHFAIL");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_PROTOCOL:          /* Failed to meet protocol. */
-		log_info("ppp_link_status_cb: PPPERR_PROTOCOL");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_PROTOCOL:          /* Failed to meet protocol. */
+			log_info("ppp_link_status_cb: PPPERR_PROTOCOL");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_PEERDEAD:          /* Connection timeout. */
-		log_info("ppp_link_status_cb: PPPERR_PEERDEAD");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_PEERDEAD:          /* Connection timeout. */
+			log_info("ppp_link_status_cb: PPPERR_PEERDEAD");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_IDLETIMEOUT:       /* Idle Timeout. */
-		log_info("ppp_link_status_cb: PPPERR_IDLETIMEOUT");
-		break;
+		case PPPERR_IDLETIMEOUT:       /* Idle Timeout. */
+			log_info("ppp_link_status_cb: PPPERR_IDLETIMEOUT");
+			break;
 
-	case PPPERR_CONNECTTIME:       /* Max connect time reached */
-		log_info("ppp_link_status_cb: PPPERR_CONNECTTIME");
-		state->conn_state = CONN_STATE_DISCONNECTED;
-		break;
+		case PPPERR_CONNECTTIME:       /* Max connect time reached */
+			log_info("ppp_link_status_cb: PPPERR_CONNECTTIME");
+			state->conn_state = CONN_STATE_DISCONNECTED;
+			break;
 
-	case PPPERR_LOOPBACK:          /* Loopback detected */
-		log_info("ppp_link_status_cb: PPPERR_LOOPBACK");
-		break;
+		case PPPERR_LOOPBACK:          /* Loopback detected */
+			log_info("ppp_link_status_cb: PPPERR_LOOPBACK");
+			break;
 
-	default:
-		log_info("ppp_link_status_cb: unknown error code: %d", err_code);
-		break;
+		default:
+			log_info("ppp_link_status_cb: unknown error code: %d", err_code);
+			break;
 	}
 
 	log_info("ppp_link_status_cb out");
@@ -419,7 +353,8 @@ static void pppos_link_status_cb(ppp_pcb *pcb, int err_code, void *ctx)
 	condSignal(state->cond);
 }
 
-static void pppos_do_rx(pppos_priv_t* state)
+
+static void pppou_do_rx(pppou_priv_t *state)
 {
 	int len;
 	u8_t buffer[1024];
@@ -428,19 +363,22 @@ static void pppos_do_rx(pppos_priv_t* state)
 			&& state->conn_state != CONN_STATE_DISCONNECTING) {
 		len = read(state->fd, buffer, sizeof(buffer));
 		if (len > 0) {
-			/* Pass received raw characters from PPPoS to be decoded through lwIP
-			* TCPIP thread using the TCPIP API. This is thread safe in all cases
-			* but you should avoid passing data byte after byte. */
-			//log_debug("%s : read() = %d", __func__, len);
+			/* Pass received raw characters from PPPoU to be decoded through lwIP
+			 * TCPIP thread using the TCPIP API. This is thread safe in all cases
+			 * but you should avoid passing data byte after byte. */
+
+			/* log_debug("%s : read() = %d", __func__, len); */
 			pppos_input_tcpip(state->ppp, buffer, len);
-		} else {
+		}
+		else {
 			if (len < 0 && errno != EINTR && errno != EWOULDBLOCK) {
 				log_error("%s() : read(%d) = %d (%d -> %s)", __func__, sizeof(buffer), len, errno, strerror(errno));
 				serial_close(state->fd);
 				state->fd = -1;
+				state->conn_state = CONN_STATE_DISCONNECTED;
 				return;
 			}
-			usleep(PPPOS_READ_DATA_TIMEOUT_STEP_MS * 1000);
+			usleep(PPPOU_READ_DATA_TIMEOUT_STEP_MS * 1000);
 		}
 	}
 
@@ -448,15 +386,13 @@ static void pppos_do_rx(pppos_priv_t* state)
 }
 
 
-static void pppos_mainLoop(void* _state)
+static void pppou_mainLoop(void *arg)
 {
-	pppos_priv_t* state = (pppos_priv_t*) _state;
-	int res;
-	int retries;
+	pppou_priv_t *state = (pppou_priv_t *)arg;
 
-	int running = 1;
+	state->thread_running = 1;
 
-	while (running) {
+	while (state->thread_running) {
 		mutexLock(state->lock);
 		while (!state->want_connected) {
 			condWait(state->cond, state->lock, 0);
@@ -464,74 +400,20 @@ static void pppos_mainLoop(void* _state)
 		mutexUnlock(state->lock);
 
 		/* Wait for the serial device */
-		if (state->fd < 0)  {
-			while ((state->fd = open(state->serialdev_fn, O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0)
-				sleep(PPPOS_TRYOPEN_SERIALDEV_SEC);
-
-			log_info("open success!");
-		}
-
-		serial_set_non_blocking(state->fd);
-#if PPPOS_DISCONNECT_ON_INIT
-		if (at_disconnect(state->fd) != AT_RESULT_OK)
-			goto fail;
-#endif
-
-#if PPPOS_USE_CONFIG_FILE
-		mutexLock(state->lock);
-		while (!state->apn[0])
-			condWait(state->cond, state->lock, 0);
-		mutexUnlock(state->lock);
-#endif
-
-		if (!at_is_responding(state->fd, 1000)) {
-			goto fail;
-		}
-
-		const char** at_cmd = at_init_cmds;
-		while (*at_cmd) {
-			if ((res = at_send_cmd(state->fd, *at_cmd, AT_INIT_CMDS_TIMEOUT_MS)) != AT_RESULT_OK) {
-				log_warn("failed to initialize modem (cmd=%s), res=%d, retrying", *at_cmd, res);
-				goto fail;
+		if (state->fd < 0) {
+			while ((state->fd = serial_open(state->serial_dev, state->serial_speed)) < 0) {
+				sleep(PPPOU_TRYOPEN_SERIALDEV_SEC);
 			}
 
-			at_cmd += 1;
-		}
-
-#if PPPOS_USE_CONFIG_FILE
-		{ /* Configure APN */
-			char at_set_apn[256];
-			if (snprintf(at_set_apn, sizeof(at_set_apn), "AT+CGDCONT=1,\"IP\",\"%s\"\r\n", state->apn) >= sizeof(at_set_apn)) {
-				log_error("APN name too long");
-				goto fail;
-			}
-
-			if ((res = at_send_cmd(state->fd, at_set_apn, 3000)) != AT_RESULT_OK) {
-				log_warn("failed to set APN, retrying");
-				goto fail;
-			}
-		}
-#endif
-
-		/* Some modems hanging on AT_CONNECT_CMD, some returning error when not ready yet.
-		 * Retrying until receive AT_RESULT_CONNECT or standard timeout is reached (res < 0)
-		 */
-		retries = AT_CONNECT_CMD_TIMEOUT_MS / PPPOS_CONNECT_CMD_RETRY_MS;
-		while ((res = at_send_cmd(state->fd, AT_CONNECT_CMD, AT_CONNECT_CMD_TIMEOUT_MS)) != AT_RESULT_CONNECT) {
-			if (retries-- <= 0 || res < 0) {
-				log_warn("failed to dial PPP, res=%d, retrying", res);
-				goto fail;
-			}
-			usleep(PPPOS_CONNECT_CMD_RETRY_MS * 1000);
+			log_info("open %s success!", state->serial_dev);
 		}
 
 		log_debug("ppp_connect");
 		state->conn_state = CONN_STATE_CONNECTING;
 		pppapi_connect(state->ppp, 0);
 
-		//serial_set_blocking(state);
 		log_debug("receiving");
-		pppos_do_rx(state);
+		pppou_do_rx(state);
 
 		log_debug("pppapi_close");
 		pppapi_close(state->ppp, 0);
@@ -546,14 +428,14 @@ static void pppos_mainLoop(void* _state)
 
 		log_debug("connection closed");
 
-fail:
 		serial_close(state->fd);
 		state->fd = -1;
+		state->conn_state = CONN_STATE_DISCONNECTED;
 
-		sleep(PPPOS_CONNECT_RETRY_SEC);
+		sleep(PPPOU_CONNECT_RETRY_SEC);
 	}
 
-	// NOTE: never tested
+	/* NOTE: never tested */
 	if (state->ppp) {
 		pppapi_close(state->ppp, 0);
 		pppapi_free(state->ppp);
@@ -563,54 +445,9 @@ fail:
 }
 
 
-static int pppos_netifUp(pppos_priv_t *state)
+static int pppou_netifUp(pppou_priv_t *state)
 {
-#if PPPOS_USE_CONFIG_FILE
-	char lcfg[256] = { 0 };
-	int line = 0;
-	FILE *fcfg = fopen(state->config_path, "r");
-	char *cfgval;
-	char *eq;
-
-	if (fcfg == NULL)
-		return 1;
-
-	if (state->apn[0]) {
-		fclose(fcfg);
-		return 0;
-	}
-
 	mutexLock(state->lock);
-	while (fgets(lcfg, sizeof(lcfg), fcfg) != NULL) {
-		line++;
-		if (lcfg[0] == '#')
-			continue;
-
-		if ((eq = strchr(lcfg, '=')) == NULL) {
-			log_error("[line %d] invalid format - missing '='", line);
-			continue;
-		}
-
-		lcfg[strcspn(lcfg, "\r\n")] = 0;
-
-		*eq = 0;
-		cfgval = eq + 1;
-
-		if (cfgval[0] == '"' || cfgval[0] == '\'') {
-			cfgval++;
-			cfgval[strlen(cfgval) - 1] = 0;
-		}
-
-		if (!strcasecmp(lcfg, "apn"))
-			strncpy(state->apn, cfgval, sizeof(state->apn) - 1);
-		else
-			log_warn("[line %d] unsupported option: %s (val: %s)", line, lcfg, cfgval);
-	}
-
-	fclose(fcfg);
-#else
-	mutexLock(state->lock);
-#endif
 	state->want_connected = 1;
 	condSignal(state->cond);
 	mutexUnlock(state->lock);
@@ -619,20 +456,13 @@ static int pppos_netifUp(pppos_priv_t *state)
 }
 
 
-static int pppos_netifDown(pppos_priv_t *state)
+static int pppou_netifDown(pppou_priv_t *state)
 {
 	/* Unconditional use of pppapi_close() in the status callback
-	can (and will) cause recursive firing of the callback */
+	 * can (and will) cause recursive firing of the callback */
 
 	mutexLock(state->lock);
-#if PPPOS_USE_CONFIG_FILE
-	if (state->apn[0]) {
-		state->apn[0] = 0;
-		state->conn_state = CONN_STATE_DISCONNECTING;
-	}
-#else
 	state->conn_state = CONN_STATE_DISCONNECTING;
-#endif
 	state->want_connected = 0;
 	mutexUnlock(state->lock);
 
@@ -640,131 +470,156 @@ static int pppos_netifDown(pppos_priv_t *state)
 }
 
 
-static pppos_priv_t *pppos_netifState(struct netif *netif)
+static pppou_priv_t *pppou_netifState(struct netif *netif)
 {
 	struct netif_alloc *s = (void *)netif;
-	pppos_priv_t *state = (void *) ((char *)s + ((sizeof(*s) + (_Alignof(pppos_priv_t) - 1)) & ~(_Alignof(pppos_priv_t) - 1)));
+	pppou_priv_t *state = (void *) ((char *)s + ((sizeof(*s) + (_Alignof(pppou_priv_t) - 1)) & ~(_Alignof(pppou_priv_t) - 1)));
 	return state;
 }
 
 
-static void pppos_statusCallback(struct netif *netif)
+static void pppou_statusCallback(struct netif *netif)
 {
-	pppos_priv_t *state = pppos_netifState(netif);
+	pppou_priv_t *state = pppou_netifState(netif);
 
 	if (netif->flags & NETIF_FLAG_UP) {
-		if (pppos_netifUp(state))
+		if (pppou_netifUp(state))
 			netif->flags &= ~NETIF_FLAG_UP;
-	} else if (pppos_netifDown(state)) {
+	}
+	else if (pppou_netifDown(state)) {
 		netif->flags |= NETIF_FLAG_UP;
 	}
 }
 
-static int pppos_netifInit(struct netif *netif, char *cfg)
+
+static char *cfg_get_next_arg(char *arg)
 {
-	pppos_priv_t* state;
+	if (arg == NULL || *arg == '\0')
+		return NULL;
+
+	for (; *arg; arg++) {
+		if (*arg == ':') {
+			*arg++ = '\0';
+			break;
+		}
+	}
+
+	return arg;
+}
 
 
-	// NOTE: netif->state cannot be used to keep our private state as it is used by LWiP PPP implementation, pass it as *ctx to callbacks
+static int pppou_netifInit(struct netif *netif, char *cfg)
+{
+	char *next;
+	pppou_priv_t *state;
+	int retries, flags = 0;
+
+	if (cfg == NULL || *cfg == '\0') {
+		log_error("no config");
+		return ERR_IF;
+	}
+
+	/*
+	 * NOTE: netif->state cannot be used to keep our private state as it is used
+	 * by LWiP PPP implementation, pass it as *ctx to callbacks
+	 */
 	state = netif->state;
 	netif->state = NULL;
 
-	memset(state, 0, sizeof(pppos_priv_t));
+	memset(state, 0, sizeof(pppou_priv_t));
+
+	state->serial_speed = B115200;
 	state->netif = netif;
-	state->serialdev_fn = cfg;
-
-	while (*cfg && *cfg != ':')
-		++cfg;
-
-	if (*cfg != ':') {
-		log_error("APN is not configured");
-		return ERR_ARG;
-	}
-
-	*cfg = 0;
-	cfg++;
-
-#if PPPOS_USE_CONFIG_FILE
-	state->config_path = cfg;
-#endif
-
-	while (*cfg && *cfg != ':')
-		++cfg;
-
-	if (*cfg == ':') {
-		*cfg = 0;
-		cfg++;
-		state->serialat_fn = cfg;
-	}
-	else {
-		state->serialat_fn = "/dev/ttyacm1";
-	}
-
 	state->fd = -1;
+
+	for (; (next = cfg_get_next_arg(cfg)); cfg = next) {
+		speed_t speed = serial_speed_from_string(cfg);
+		if (speed > 0) {
+			state->serial_speed = speed;
+			log_info("config speed: %s bps => %d", cfg, speed);
+			continue;
+		}
+
+		if (!strncmp(cfg, "/dev/", 5)) {
+			state->serial_dev = cfg;
+			log_info("config device: ", cfg);
+			continue;
+		}
+
+		if (strcmp(cfg, "up") == 0) {
+			flags |= CFG_FLAG_DEFAULT_UP;
+			log_info("config up: yes");
+			continue;
+		}
+
+		/* TODO: extend with other flags */
+	}
+
+	if (!state->serial_dev) {
+		log_error("no device");
+		return ERR_IF;
+	}
 
 	mutexCreate(&state->lock);
 	condCreate(&state->cond);
 
+	/* FIXME: resolve `pp` name conflict with `pppos`
+	 * and is required for e.g. netif_is_ppp() */
 	netif->name[0] = 'p';
 	netif->name[1] = 'p';
 
-	if (!cfg)
-		return ERR_ARG;
-
 	if (!state->ppp) {
-		state->ppp = pppapi_pppos_create(state->netif, pppos_output_cb, pppos_link_status_cb, state);
+		state->ppp = pppapi_pppos_create(state->netif, pppou_output_cb, pppou_link_status_cb, state);
 
 		if (!state->ppp) {
 			log_error("could not create PPP control interface");
-			return ERR_IF ; // TODO: maybe permanent broken state?
+			return ERR_IF; /* TODO: maybe permanent broken state? */
 		}
 		netif->flags &= ~NETIF_FLAG_UP;
-		ppp_set_netif_statuscallback(state->ppp, pppos_statusCallback);
+		ppp_set_netif_statuscallback(state->ppp, pppou_statusCallback);
 	}
 
-	beginthread(pppos_mainLoop, 4, (void *)state->main_loop_stack, sizeof(state->main_loop_stack), state);
+	beginthread(pppou_mainLoop, 4, (void *)state->main_loop_stack, sizeof(state->main_loop_stack), state);
+
+	/* FIXME: (imxrt106x) the below blocking loop is temporary
+	 * because of lack of real ifconfig on the target platform
+	 */
+	for (retries = 3; retries > 0; retries--) {
+		/* wait until thread started */
+		if (!state->thread_running) {
+			sleep(1);
+			continue;
+		}
+
+		if (flags & CFG_FLAG_DEFAULT_UP) {
+			log_info("pppou netif up");
+			netif_set_up(netif);
+		}
+
+		break;
+	}
 
 	return ERR_OK;
 }
 
 
-const char *pppos_media(struct netif *netif)
+const char *pppou_media(struct netif *netif)
 {
-	pppos_priv_t *state = pppos_netifState(netif);
-	int fd = open(state->serialat_fn, O_RDWR | O_NONBLOCK);
-	char buffer[256];
-	int result;
-
-	if (fd < 0)
-		return "error/open";
-
-	if ((result = at_send_cmd_res(fd, "AT+COPS?\r\n", 300, buffer, sizeof(buffer))) != AT_RESULT_OK)
-		return "error/read";
-
-	close(fd);
-
-	if (strstr(buffer, "\",0") != NULL)
-		return "2G";
-	else if (strstr(buffer, "\",2") != NULL)
-		return "3G";
-	else if (strstr(buffer, "\",7") != NULL || strstr(buffer, "\",9") != NULL)
-		return "4G";
-	else
-		return "unrecognized";
+	return "null-modem";
 }
 
 
-static netif_driver_t pppos_drv = {
-	.init = pppos_netifInit,
-	.state_sz = sizeof(pppos_priv_t),
-	.state_align = _Alignof(pppos_priv_t),
-	.name = "pppos",
-	.media = pppos_media,
+static netif_driver_t pppou_drv = {
+	.init = pppou_netifInit,
+	.state_sz = sizeof(pppou_priv_t),
+	.state_align = _Alignof(pppou_priv_t),
+	.name = "pppou",
+	.media = pppou_media,
 };
 
 
 __constructor__(1000)
-void register_driver_pppos(void)
+void register_driver_pppou(void)
 {
-	register_netif_driver(&pppos_drv);
+	register_netif_driver(&pppou_drv);
 }

--- a/port/main.c
+++ b/port/main.c
@@ -207,6 +207,7 @@ int main(int argc, char **argv)
 	void register_driver_rtl(void);
 	void register_driver_enet(void);
 	void register_driver_pppos(void);
+	void register_driver_pppou(void);
 	void register_driver_tun(void);
 	void register_driver_tap(void);
 
@@ -220,6 +221,9 @@ int main(int argc, char **argv)
 #endif
 #ifdef HAVE_DRIVER_pppos
 	register_driver_pppos();
+#endif
+#ifdef HAVE_DRIVER_pppou
+	register_driver_pppou();
 #endif
 #ifdef HAVE_DRIVER_tuntap
 	register_driver_tun();


### PR DESCRIPTION
This changes brings an easy support for the IoT, device to device, connections on `armv7m7-imxrt106x` target. The `ppp over uart`/serial driver can be used with virtually any `phoenix-rtos` target that support uart, that being said, enabling easy porting of the `phoenix-rtos-lwip` to other IoT targets. **Developing IoT applications can be easier even on targets without ethernet, bluetooth and wifi**, but with simple point-to-point serial/uart null-modem connection.  Why `pppou` instead of already present `pppos` driver?  The answer is simple as `pppos` support modem GSM/GPRS/LTE communication (Hayes AT-command chat) I don't want to break that functionality, so `pppou` safetly derived for a null-modem implementation that doesn't depend on any other things than `phoenix-rtos-lwip` and  `phoenix-rtos` itself.

See it in action with debuging enabled:

https://user-images.githubusercontent.com/141153/104374934-e5f1a500-5522-11eb-95d8-438547535d2b.mp4
