### PR TITLE
port: Fix ioctl warnings

### DIFF
--- a/port/sockets.c
+++ b/port/sockets.c
@@ -9,6 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <sys/ioctl.h>
+
 #define ifreq lwip_ifreq
 #include <lwip/netdb.h>
 #include <lwip/sockets.h>
@@ -18,6 +20,7 @@
 #include <lwip/dhcp.h>
 #include <lwip/prot/dhcp.h>
 #undef ifreq
+#undef IFNAMSIZ
 
 #include <errno.h>
 #include <poll.h>


### PR DESCRIPTION
This PR, combined with https://github.com/phoenix-rtos/libphoenix/pull/76 fixes loads of ugly warnings when building lwip, e.g.:
![Screenshot from 2021-01-29 12-19-47](https://user-images.githubusercontent.com/26349182/106269101-57706980-622c-11eb-835a-d5769898af77.png)

I know, the solution is hacky, but it seems like the simplest way to fix it without changing the whole idea of using both `libphoenix` and `lwip` headers in `phoenix-rtos-lwip/port/sockets.c`. However, I'm opened to comments and other ideas.