### PR TITLE
port: Fix building when IPv6 enabled

### DIFF
--- a/port/devs.c
+++ b/port/devs.c
@@ -141,9 +141,9 @@ static int route_open(int flags)
 
 	/* add per-netif routing (LwIP uses it regardless of our routing table) - with highest priority (apart for our custom GW) */
 	for (netif = netif_list; netif != NULL; netif = netif->next) {
-		uint32_t prefix = ((netif->ip_addr.addr) & (netif->netmask.addr));
+		uint32_t prefix = ip4_addr_get_u32(netif_ip4_addr(netif)) & ip4_addr_get_u32(netif_ip4_netmask(netif));
 		unsigned int flags = netif_is_up(netif) ? RTF_UP : 0;
-		if (netif->gw.addr != 0)
+		if (ip4_addr_get_u32(netif_ip4_gw(netif)) != 0)
 			flags |= RTF_GATEWAY;
 
 		SNPRINTF_APPEND("%2s%u\t%08X\t%08X\t%04X\t%d\t%u\t%d\t%08X\t%d\t%u\t%u\n",


### PR DESCRIPTION
JIRA: G3-84

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change fixes building lwip, when IPv6 is enabled in lwipopts.h

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required in order to run IPv6 based projects including G3 Adaptation layer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
