### PR TITLE
sockets: write size check fix

### DIFF
--- a/port/sockets.c
+++ b/port/sockets.c
@@ -723,13 +723,13 @@ static int socket_op(msg_t *msg, int sock)
 		smo->ret = map_errno(lwip_shutdown(sock, smi->send.flags));
 		break;
 	case mtRead:
-		if (msg->o.size < 1ull << (8 * sizeof(int) - 1))
+		if (msg->o.size <= SSIZE_MAX)
 			msg->o.io.err = map_errno(lwip_read(sock, msg->o.data, msg->o.size));
 		else
 			msg->o.io.err = -EINVAL;
 		break;
 	case mtWrite:
-		if (msg->o.size < 1ull << (8 * sizeof(int) - 1))
+		if (msg->i.size <= SSIZE_MAX)
 			msg->o.io.err = map_errno(lwip_write(sock, msg->i.data, msg->i.size));
 		else
 			msg->o.io.err = -EINVAL;


### PR DESCRIPTION
JIRA: RTOS-106

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fix typo in write size check. Use POSIX friendly SSIZE_MAX instead of home made INT_MAX.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
