### PR TITLE
wi-fi: get FW, CLM and NVRAM based on chip id

### DIFF
--- a/wi-fi/whd/whd_resources.c
+++ b/wi-fi/whd/whd_resources.c
@@ -19,6 +19,7 @@
  * Defines WHD resource functions for AW-NM512 platform
  */
 #include "whd_resource_api.h"
+#include "whd_chip_constants.h"
 #include "wifi_nvram_image.h"
 
 #include <stdio.h>
@@ -27,12 +28,10 @@
 #include <unistd.h>
 
 
-// #define FIRMWARE_FILENAME "/firmware/brcmfmac43439-sdio.bin"
-// #define CLM_FILENAME      "/firmware/brcmfmac43439-sdio.clm_blob"
-// #define FIRMWARE_FILENAME "/firmware/43439A0.bin"
-// #define CLM_FILENAME      "/firmware/43439A0.clm_blob"
-#define FIRMWARE_FILENAME "/firmware/brcmfmac43430-sdio-prod.bin"
-#define CLM_FILENAME      "/firmware/brcmfmac43430-sdio.clm_blob"
+#define AW_NM512_FIRMWARE_FILENAME     "/firmware/43439A0.bin"
+#define AW_NM512_CLM_FILENAME          "/firmware/43439A0.clm_blob"
+#define STERLING_LWB_FIRMWARE_FILENAME "/firmware/brcmfmac43430-sdio-prod.bin"
+#define STERLING_LWB_CLM_FILENAME      "/firmware/brcmfmac43430-sdio.clm_blob"
 
 
 static uint8_t resource_buf[BLOCK_SIZE];
@@ -70,21 +69,84 @@ int read_file(const char *filename, off_t pos, size_t len, uint8_t *buf)
 }
 
 
+static const char *host_firmware_filename(whd_driver_t whd_drv)
+{
+	uint16_t chip_id = whd_chip_get_chip_id(whd_drv);
+
+	if (chip_id == 43430)
+		return STERLING_LWB_FIRMWARE_FILENAME;
+	else if (chip_id == 43439)
+		return AW_NM512_FIRMWARE_FILENAME;
+	else
+		return NULL;
+}
+
+
+static const char *host_clm_filename(whd_driver_t whd_drv)
+{
+	uint16_t chip_id = whd_chip_get_chip_id(whd_drv);
+
+	if (chip_id == 43430)
+		return STERLING_LWB_CLM_FILENAME;
+	else if (chip_id == 43439)
+		return AW_NM512_CLM_FILENAME;
+	else
+		return NULL;
+}
+
+
+static const char *host_nvram_image(whd_driver_t whd_drv)
+{
+	uint16_t chip_id = whd_chip_get_chip_id(whd_drv);
+
+	if (chip_id == 43430)
+		return sterling_lwb_wifi_nvram_image;
+	else if (chip_id == 43439)
+		return aw_nm512_wifi_nvram_image;
+	else
+		return NULL;
+}
+
+
+static ssize_t host_nvram_size(whd_driver_t whd_drv)
+{
+	uint16_t chip_id = whd_chip_get_chip_id(whd_drv);
+
+	if (chip_id == 43430)
+		return sizeof(sterling_lwb_wifi_nvram_image);
+	else if (chip_id == 43439)
+		return sizeof(aw_nm512_wifi_nvram_image);
+	else
+		return -1;
+}
+
+
 uint32_t host_resource_size(whd_driver_t whd_drv, whd_resource_type_t resource, uint32_t *size_out)
 {
+	const char *filename;
 	off_t fsize;
+	ssize_t isize;
 
 	switch (resource) {
 		case WHD_RESOURCE_WLAN_FIRMWARE:
-			if ((fsize = get_file_size(FIRMWARE_FILENAME)) < 0)
+			filename = host_firmware_filename(whd_drv);
+			if (filename == NULL)
+				return WHD_HAL_ERROR;
+			if ((fsize = get_file_size(filename)) < 0)
 				return WHD_HAL_ERROR;
 			*size_out = fsize;
 			break;
 		case WHD_RESOURCE_WLAN_NVRAM:
-			*size_out = sizeof(wifi_nvram_image);
+			isize = host_nvram_size(whd_drv);
+			if (isize < 0)
+				return WHD_HAL_ERROR;
+			*size_out = isize;
 			break;
 		case WHD_RESOURCE_WLAN_CLM:
-			if ((fsize = get_file_size(CLM_FILENAME)) < 0)
+			filename = host_clm_filename(whd_drv);
+			if (filename == NULL)
+				return WHD_HAL_ERROR;
+			if ((fsize = get_file_size(filename)) < 0)
 				return WHD_HAL_ERROR;
 			*size_out = fsize;
 			break;
@@ -116,6 +178,7 @@ uint32_t host_get_resource_no_of_blocks(whd_driver_t whd_drv, whd_resource_type_
 
 uint32_t host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type, uint32_t blockno, const uint8_t **data, uint32_t *size_out)
 {
+	const char *filename, *image;
 	uint32_t result, resource_size, block_count, block_pos, block_size;
 
 	if ((result = host_resource_size(whd_drv, type, &resource_size)) != WHD_SUCCESS)
@@ -138,14 +201,23 @@ uint32_t host_get_resource_block(whd_driver_t whd_drv, whd_resource_type_t type,
 
 	switch (type) {
 		case WHD_RESOURCE_WLAN_FIRMWARE:
-			if (read_file(FIRMWARE_FILENAME, block_pos, block_size, resource_buf) < 0)
+			filename = host_firmware_filename(whd_drv);
+			if (filename == NULL)
+				return WHD_HAL_ERROR;
+			if (read_file(filename, block_pos, block_size, resource_buf) < 0)
 				return WHD_HAL_ERROR;
 			break;
 		case WHD_RESOURCE_WLAN_NVRAM:
-			memcpy(resource_buf, wifi_nvram_image + block_pos, block_size);
+			image = host_nvram_image(whd_drv);
+			if (image == NULL)
+				return WHD_HAL_ERROR;
+			memcpy(resource_buf, image + block_pos, block_size);
 			break;
 		case WHD_RESOURCE_WLAN_CLM:
-			if (read_file(CLM_FILENAME, block_pos, block_size, resource_buf) < 0)
+			filename = host_clm_filename(whd_drv);
+			if (filename == NULL)
+				return WHD_HAL_ERROR;
+			if (read_file(filename, block_pos, block_size, resource_buf) < 0)
 				return WHD_HAL_ERROR;
 			break;
 		default:

--- a/wi-fi/whd/wifi_nvram_image.h
+++ b/wi-fi/whd/wifi_nvram_image.h
@@ -8,12 +8,11 @@
 extern "C" {
 #endif
 
-#if 0
 /**
  * Character array of NVRAM image
  * Generated from brcmfmac43439-sdio_210707.txt
  */
-static const char wifi_nvram_image[] =
+static const char aw_nm512_wifi_nvram_image[] =
 	"NVRAMRev=$Rev$\0"
 	"manfid=0x2d0\0"
 	"prodid=0x0727\0"
@@ -59,69 +58,14 @@ static const char wifi_nvram_image[] =
 	"edonthd20l=-72\0"
 	"edoffthd20ul=-78\0"
 	"\0\0";
-#endif
 
-#if 0
-/**
- * Character array of NVRAM image
- * Generated from cyw943439wlpth_rev1_0.txt
- */
 
-static const char wifi_nvram_image[] =
-	"NVRAMRev=$Rev$\0"
-	"manfid=0x2d0\0"
-	"prodid=0x0727\0"
-	"vendid=0x14e4\0"
-	"devid=0x43e2\0"
-	"boardtype=0x0887\0"
-	"boardrev=0x1100\0"
-	"boardnum=22\0"
-	"sromrev=11\0"
-	"boardflags=0x00404001\0"
-	"boardflags3=0x04000000\0"
-	"xtalfreq=26000\0"
-	"nocrc=1\0"
-	"ag0=255\0"
-	"aa2g=1\0"
-	"ccode=ALL\0"
-	"pa0itssit=0x20\0"
-	"extpagain2g=0\0"
-	"pa2ga0=-168,7161,-820\0"
-	"AvVmid_c0=0x0,0xc8\0"
-	"cckpwroffset0=5\0"
-	"maxp2ga0=84\0"
-	"txpwrbckof=6\0"
-	"cckbw202gpo=0\0"
-	"legofdmbw202gpo=0x66111111\0"
-	"mcsbw202gpo=0x77711111\0"
-	"propbw202gpo=0xdd\0"
-	"ofdmdigfilttype=18\0"
-	"ofdmdigfilttypebe=18\0"
-	"papdmode=1\0"
-	"papdvalidtest=1\0"
-	"pacalidx2g=45\0"
-	"papdepsoffset=-30\0"
-	"papdendidx=58\0"
-	"ltecxmux=0\0"
-	"ltecxpadnum=0x0102\0"
-	"ltecxfnsel=0x44\0"
-	"ltecxgcigpio=0x01\0"
-	"wl0id=0x431b\0"
-	"deadman_to=0xffffffff\0"
-	"muxenab=0x1\0"
-	"spurconfig=0x3\0"
-	"glitch_based_crsmin=1\0"
-	"btc_mode=0\0"
-	"\0\0";
-#endif
-
-#if 1
 /**
  * Character array of NVRAM image
  * Generated from brcmfmac43430-sdio-etsi.txt
  */
 
-static const char wifi_nvram_image[] =
+static const char sterling_lwb_wifi_nvram_image[] =
 	"manfid=0x2d0\0"
 	"prodid=0x0726\0"
 	"vendid=0x14e4\0"
@@ -160,7 +104,6 @@ static const char wifi_nvram_image[] =
 	"muxenab=0x11\0"
 	"spurconfig=0x3\0"
 	"\0\0";
-#endif
 
 #ifdef __cplusplus
 } /*extern "C" */


### PR DESCRIPTION
Currently two Wi-Fi modules are supported:
 - AW-NM512 (CYW43439)
 - Sterling-LWB (BCM4343W)

JIRA: DTR-235

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
