### PR TITLE
makes: don't install internal headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@
 
 include ../phoenix-rtos-build/Makefile.common
 
+# set local path manually as we're including other Makefiles here (as an empty var - TOPDIR)
+LOCAL_DIR :=
+
 .DEFAULT_GOAL := all
 
 LWIPOPTS_DIR ?= "include/default-opts"
@@ -30,6 +33,8 @@ CFLAGS += -Wundef -Iinclude -Ilib-lwip/src/include -I"$(LWIPOPTS_DIR)"
 
 NAME := lwip-core
 SRCS := $(LWIP_SRCS)
+# don't install include subdir contents, these are actually internal headers
+LOCAL_HEADER_DIR := nothing
 include $(static-lib.mk)
 
 # should define NET_DRIVERS and platform driver sources


### PR DESCRIPTION
## Description
Needed for the new Makefiles with header auto-install.

The problem was twofold:
- LOCAL_DIR value was invalid due to additional Makefile imports (and
defining component in root Makefile)
 - the "include" dir consists of internal includes - not external API


## Motivation and Context
JIRA: CI-59

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/phoenix-rtos-build/pull/102
- [ ] I will merge this PR by myself when appropriate.
