### PR TITLE
port/devs: Provide statistics by reading from /dev/ipstats

### DIFF
--- a/include/default-opts/lwipopts.h
+++ b/include/default-opts/lwipopts.h
@@ -44,6 +44,26 @@
 #define PBUF_DEBUG LWIP_DBG_OFF
 #define SOCKETS_DEBUG LWIP_DBG_ON
 #endif
+
+#ifndef LWIP_STATS
+#define LWIP_STATS 0
+#endif
+
+#if LWIP_STATS
+#define LWIP_STATS_DISPLAY 1
+#define LINK_STATS         1
+#define IP_STATS           1
+#define ICMP_STATS         1
+#define IGMP_STATS         1
+#define IPFRAG_STATS       1
+#define UDP_STATS          1
+#define TCP_STATS          1
+#define MEM_STATS          1
+#define MEMP_STATS         1
+#define PBUF_STATS         1
+#define SYS_STATS          1
+#endif /* LWIP_STATS */
+
 #define TCP_MSS 1460
 #define TCP_WND (32 * TCP_MSS)
 #define TCP_SND_BUF TCP_WND


### PR DESCRIPTION
JIRA: DTR-288

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change enables retrieving lwip statistics using `/dev/ipstats` device node. One has to set `LWIP_STATS` to 1 in a project's `lwipopts.h` file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is useful for lwip debugging issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
