### PR TITLE
lwip: Fix incorrect use of printf %s

### DIFF
--- a/ipsec/ipsecdev.c
+++ b/ipsec/ipsecdev.c
@@ -183,7 +183,7 @@ static err_t ipsecdev_ip_input(struct pbuf *p, struct netif *netif)
 
 			/* change in-tunnel dst-IP if needed (Virtual IP) */
 			if (!ip_addr_isany(&(ipsecdev->ip_addr)) && ip_addr_cmp(&iph->dest, &ipsecdev->ip_addr) && !ip_addr_isany(&netif->ip_addr)) {
-				IPSEC_LOG_DBG(IPSEC_STATUS_SUCCESS, "%2s%u: DNAT after IPsec: %08lx to %08lx",
+				IPSEC_LOG_DBG(IPSEC_STATUS_SUCCESS, "%.2s%u: DNAT after IPsec: %08lx to %08lx",
 					netif->name, netif->num, lwip_ntohl(iph->dest.addr), lwip_ntohl(netif->ip_addr.addr));
 				ipsecdev_apply_static_nat(iph, netif->ip_addr.addr, 0);
 			}
@@ -280,7 +280,7 @@ static err_t ipsecdev_output(struct netif *netif, struct pbuf *p, const ip4_addr
 	if ((state->flags & IPSEC_FLAGS_ENABLED) == 0)
 		return state->hw_output(state->hw_netif, p, ipaddr);
 
-	IPSEC_LOG_TRC(IPSEC_TRACE_ENTER, "pbuf=%p, netif=%2s%u", p, netif->name, netif->num);
+	IPSEC_LOG_TRC(IPSEC_TRACE_ENTER, "pbuf=%p, netif=%.2s%u", p, netif->name, netif->num);
 
 	if (p->next != NULL) {
 		pbuf_ref(p);
@@ -320,7 +320,7 @@ static err_t ipsecdev_output(struct netif *netif, struct pbuf *p, const ip4_addr
 
 	/* change in-tunnle src-IP (Virtual IP) */
 	if (spd->policy == IPSEC_POLICY_IPSEC && !ip_addr_isany(&ipsecdev->ip_addr) && !ip_addr_cmp(&ip->src, &ipsecdev->ip_addr)) {
-		IPSEC_LOG_DBG(IPSEC_STATUS_SUCCESS, "%2s%u: SNAT before IPsec: %08lx as %08lx",
+		IPSEC_LOG_DBG(IPSEC_STATUS_SUCCESS, "%.2s%u: SNAT before IPsec: %08lx as %08lx",
 			netif->name, netif->num, lwip_ntohl(ip->src.addr), lwip_ntohl(ipsecdev->ip_addr.addr));
 		ipsecdev_apply_static_nat(ip, ipsecdev->ip_addr.addr, 1);
 	}

--- a/port/devs.c
+++ b/port/devs.c
@@ -142,7 +142,7 @@ static int route_open(int flags)
 
 	if ((entry = rt_table.entries) != NULL) {
 		do {
-			SNPRINTF_APPEND("%2s%u\t%08X\t%08X\t%04X\t%d\t%u\t%d\t%08X\t%d\t%u\t%u\n",
+			SNPRINTF_APPEND("%.2s%u\t%08X\t%08X\t%04X\t%d\t%u\t%d\t%08X\t%d\t%u\t%u\n",
 				entry->netif->name, entry->netif->num,
 				ip4_addr_get_u32(&entry->dst),                                                          /* Destination */
 				ip4_addr_get_u32(entry->flags & RTF_GATEWAY ? &entry->gw : netif_ip4_gw(entry->netif)), /* Gateway */
@@ -161,7 +161,7 @@ static int route_open(int flags)
 		if (ip4_addr_get_u32(netif_ip4_gw(netif)) != 0)
 			flags |= RTF_GATEWAY;
 
-		SNPRINTF_APPEND("%2s%u\t%08X\t%08X\t%04X\t%d\t%u\t%d\t%08X\t%d\t%u\t%u\n",
+		SNPRINTF_APPEND("%.2s%u\t%08X\t%08X\t%04X\t%d\t%u\t%d\t%08X\t%d\t%u\t%u\n",
 			netif->name, netif->num,
 			prefix,                                /* Destination */
 			ip4_addr_get_u32(netif_ip4_gw(netif)), /* Gateway */
@@ -227,28 +227,28 @@ static int ifstatus_open(int flags)
 	size = sizeof(devs_common.ifstatus.buf);
 
 	for (netif = netif_list; netif != NULL; netif = netif->next) {
-		SNPRINTF_APPEND("%2s%d_up=%u\n", netif->name, netif->num, netif_is_up(netif));
-		SNPRINTF_APPEND("%2s%d_link=%u\n", netif->name, netif->num, netif_is_link_up(netif));
-		SNPRINTF_APPEND("%2s%d_ip=%s\n", netif->name, netif->num, inet_ntoa(netif->ip_addr));
+		SNPRINTF_APPEND("%.2s%d_up=%u\n", netif->name, netif->num, netif_is_up(netif));
+		SNPRINTF_APPEND("%.2s%d_link=%u\n", netif->name, netif->num, netif_is_link_up(netif));
+		SNPRINTF_APPEND("%.2s%d_ip=%s\n", netif->name, netif->num, inet_ntoa(netif->ip_addr));
 		if (!netif_is_ppp(netif) && !netif_is_tun(netif)) {
 #if LWIP_DHCP
-			SNPRINTF_APPEND("%2s%d_dhcp=%u\n", netif->name, netif->num, netif_is_dhcp(netif));
+			SNPRINTF_APPEND("%.2s%d_dhcp=%u\n", netif->name, netif->num, netif_is_dhcp(netif));
 #endif
-			SNPRINTF_APPEND("%2s%d_netmask=%s\n", netif->name, netif->num, inet_ntoa(netif->netmask));
-			SNPRINTF_APPEND("%2s%d_gateway=%s\n", netif->name, netif->num, inet_ntoa(netif->gw));
+			SNPRINTF_APPEND("%.2s%d_netmask=%s\n", netif->name, netif->num, inet_ntoa(netif->netmask));
+			SNPRINTF_APPEND("%.2s%d_gateway=%s\n", netif->name, netif->num, inet_ntoa(netif->gw));
 #if LWIP_DHCP_GET_MOBILE_AGENT
 			if (netif_is_dhcp(netif))
-				SNPRINTF_APPEND("%2s%d_mobile_agent=%s\n", netif->name, netif->num, inet_ntoa(netif->mobile_agent));
+				SNPRINTF_APPEND("%.2s%d_mobile_agent=%s\n", netif->name, netif->num, inet_ntoa(netif->mobile_agent));
 #endif
 		}
 		else {
-			SNPRINTF_APPEND("%2s%d_ptp=%s\n", netif->name, netif->num, inet_ntoa(netif->gw));
+			SNPRINTF_APPEND("%.2s%d_ptp=%s\n", netif->name, netif->num, inet_ntoa(netif->gw));
 		}
 
 		if (strncmp("lo", netif->name, sizeof(netif->name)) != 0 && strncmp("wl", netif->name, sizeof(netif->name)) != 0 && strncmp("sc", netif->name, sizeof(netif->name)) != 0) {
 			drv = netif_driver(netif);
 			if (drv != NULL && drv->media != NULL)
-				SNPRINTF_APPEND("%2s%d_media=%s\n", netif->name, netif->num, drv->media(netif));
+				SNPRINTF_APPEND("%.2s%d_media=%s\n", netif->name, netif->num, drv->media(netif));
 		}
 	}
 

--- a/port/sockets.c
+++ b/port/sockets.c
@@ -1077,7 +1077,7 @@ static int do_getifaddrs(char *buf, size_t *buflen)
 		dest->ifa_netmask = (struct sockaddr *)(addrdest - buf);
 		addrdest += sizeof(struct sockaddr_in);
 
-		snprintf(strdest, sizeof(netif->name) + 2, "%2s%1u", netif->name, netif->num % 10);
+		snprintf(strdest, sizeof(netif->name) + 2, "%.2s%1u", netif->name, netif->num % 10);
 		dest->ifa_name = (char *)(strdest - buf);
 #if LWIP_IPV6
 		sin6 = (struct sockaddr_in6 *) &sa;


### PR DESCRIPTION
printf("%2s", string); prints at least 2 characters from string printf("%.2s", string); prints at most 2 characters from string

Before fix in https://github.com/phoenix-rtos/libphoenix/pull/228 "%2s" used to work like "%.2s".

DONE: RTOS-403

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
