### PR TITLE
drivers/ephy: more dynamic support for KSZ8081 RNA/RND variants

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,7 +1,9 @@
 # Makefile for lwip drivers to be included
 
-# TODO: make every driver a separate component?
-ifneq ($(EPHY_KSZ8081RND),)
+ifeq ($(EPHY_KSZ8081),RNA)
+  LOCAL_CFLAGS := -DEPHY_KSZ8081RNA
+endif
+ifeq ($(EPHY_KSZ8081),RND)
   LOCAL_CFLAGS := -DEPHY_KSZ8081RND
 endif
 

--- a/drivers/ephy.h
+++ b/drivers/ephy.h
@@ -15,6 +15,7 @@
 
 #include <sys/types.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef void (*link_state_cb_t)(void* arg, int state);
 
@@ -34,5 +35,8 @@ typedef struct {
 
 int ephy_init(eth_phy_state_t *phy, char *conf, link_state_cb_t cb, void *cb_arg);
 int ephy_link_speed(eth_phy_state_t *phy, int *full_duplex);
+
+/* toggle MACPHY internal loopback for test mode */
+int ephy_enableLoopback(eth_phy_state_t *phy, bool enable);
 
 #endif /* NET_EPHY_H_ */

--- a/drivers/ephy.h
+++ b/drivers/ephy.h
@@ -33,7 +33,7 @@ typedef struct {
 } eth_phy_state_t;
 
 
-int ephy_init(eth_phy_state_t *phy, char *conf, link_state_cb_t cb, void *cb_arg);
+int ephy_init(eth_phy_state_t *phy, char *conf, uint8_t board_rev, link_state_cb_t cb, void *cb_arg);
 int ephy_link_speed(eth_phy_state_t *phy, int *full_duplex);
 
 /* toggle MACPHY internal loopback for test mode */

--- a/drivers/imx6-enet-regs.h
+++ b/drivers/imx6-enet-regs.h
@@ -125,8 +125,69 @@ struct enet_regs {
 #define ENET_RACC_IPDIS		BIT(1)		// discard frames with IPv4 checksum error
 #define ENET_RACC_PADREM	BIT(0)		// remove ethernet payload padding from short IP frames
 	R_RESERVED(0x1C8, 0x200);
-	uint32_t		stats[64];	// various stats counters (32-bit each)
+
+	union {
+		uint32_t rawstats[64];  // various stats counters (32-bit each)
 #define ENET_VALID_COUTERS	0x01FFFFFE1FFFFFFFull
+		struct {
+			uint32_t RMON_T_DROP;        /* Count of frames not cntd correctly */
+			uint32_t RMON_T_PACKETS;     /* RMON TX packet count */
+			uint32_t RMON_T_BC_PKT;      /* RMON TX broadcast pkts */
+			uint32_t RMON_T_MC_PKT;      /* RMON TX multicast pkts */
+			uint32_t RMON_T_CRC_ALIGN;   /* RMON TX pkts with CRC align err */
+			uint32_t RMON_T_UNDERSIZE;   /* RMON TX pkts < 64 bytes, good CRC */
+			uint32_t RMON_T_OVERSIZE;    /* RMON TX pkts > MAX_FL bytes good CRC */
+			uint32_t RMON_T_FRAG;        /* RMON TX pkts < 64 bytes, bad CRC */
+			uint32_t RMON_T_JAB;         /* RMON TX pkts > MAX_FL bytes, bad CRC */
+			uint32_t RMON_T_COL;         /* RMON TX collision count */
+			uint32_t RMON_T_P64;         /* RMON TX 64 byte pkts */
+			uint32_t RMON_T_P65TO127;    /* RMON TX 65 to 127 byte pkts */
+			uint32_t RMON_T_P128TO255;   /* RMON TX 128 to 255 byte pkts */
+			uint32_t RMON_T_P256TO511;   /* RMON TX 256 to 511 byte pkts */
+			uint32_t RMON_T_P512TO1023;  /* RMON TX 512 to 1023 byte pkts */
+			uint32_t RMON_T_P1024TO2047; /* RMON TX 1024 to 2047 byte pkts */
+			uint32_t RMON_T_P_GTE2048;   /* RMON TX pkts > 2048 bytes */
+			uint32_t RMON_T_OCTETS;      /* RMON TX octets */
+			uint32_t IEEE_T_DROP;        /* Count of frames not counted correctly */
+			uint32_t IEEE_T_FRAME_OK;    /* Frames tx'd OK */
+			uint32_t IEEE_T_1COL;        /* Frames tx'd with single collision */
+			uint32_t IEEE_T_MCOL;        /* Frames tx'd with multiple collision */
+			uint32_t IEEE_T_DEF;         /* Frames tx'd after deferral delay */
+			uint32_t IEEE_T_LCOL;        /* Frames tx'd with late collision */
+			uint32_t IEEE_T_EXCOL;       /* Frames tx'd with excessive collisions */
+			uint32_t IEEE_T_MACERR;      /* Frames tx'd with TX FIFO underrun */
+			uint32_t IEEE_T_CSERR;       /* Frames tx'd with carrier sense err */
+			uint32_t IEEE_T_SQE;         /* Frames tx'd with SQE err */
+			uint32_t IEEE_T_FDXFC;       /* Flow control pause frames tx'd */
+			uint32_t IEEE_T_OCTETS_OK;   /* Octet count for frames tx'd w/o err */
+			uint32_t __reserved3[3];
+			uint32_t RMON_R_PACKETS;     /* RMON RX packet count */
+			uint32_t RMON_R_BC_PKT;      /* RMON RX broadcast pkts */
+			uint32_t RMON_R_MC_PKT;      /* RMON RX multicast pkts */
+			uint32_t RMON_R_CRC_ALIGN;   /* RMON RX pkts with CRC alignment err */
+			uint32_t RMON_R_UNDERSIZE;   /* RMON RX pkts < 64 bytes, good CRC */
+			uint32_t RMON_R_OVERSIZE;    /* RMON RX pkts > MAX_FL bytes good CRC */
+			uint32_t RMON_R_FRAG;        /* RMON RX pkts < 64 bytes, bad CRC */
+			uint32_t RMON_R_JAB;         /* RMON RX pkts > MAX_FL bytes, bad CRC */
+			uint32_t RMON_R_RESVD_O;     /* Reserved */
+			uint32_t RMON_R_P64;         /* RMON RX 64 byte pkts */
+			uint32_t RMON_R_P65TO127;    /* RMON RX 65 to 127 byte pkts */
+			uint32_t RMON_R_P128TO255;   /* RMON RX 128 to 255 byte pkts */
+			uint32_t RMON_R_P256TO511;   /* RMON RX 256 to 511 byte pkts */
+			uint32_t RMON_R_P512TO1023;  /* RMON RX 512 to 1023 byte pkts */
+			uint32_t RMON_R_P1024TO2047; /* RMON RX 1024 to 2047 byte pkts */
+			uint32_t RMON_R_P_GTE2048;   /* RMON RX pkts > 2048 bytes */
+			uint32_t RMON_R_OCTETS;      /* RMON RX octets */
+			uint32_t IEEE_R_DROP;        /* Count frames not counted correctly */
+			uint32_t IEEE_R_FRAME_OK;    /* Frames rx'd OK */
+			uint32_t IEEE_R_CRC;         /* Frames rx'd with CRC err */
+			uint32_t IEEE_R_ALIGN;       /* Frames rx'd with alignment err */
+			uint32_t IEEE_R_MACERR;      /* Receive FIFO overflow count */
+			uint32_t IEEE_R_FDXFC;       /* Flow control pause frames rx'd */
+			uint32_t IEEE_R_OCTETS_OK;   /* Octet cnt for frames rx'd w/o err */
+			uint32_t __reserved7[7];
+		} stats;
+	};
 	R_RESERVED(0x300, 0x400);
 	uint32_t		ATCR;		// timer command
 	uint32_t		ATVR;		// timer value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- drivers/ephy: add MACPHY self-test
  Add MACPHY test using local loopback mode

- drivers/ephy: add support for alternative configurations
  - read / pass board revision to ephy_init
  - add option for custom init hook to select alternative phy configuration
  - rewrite RND/RNA ext config logic override


## Motivation and Context
 JIRA: DTR-480

Needed for DTRv2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: DTR, DTRv2

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
