### PR TITLE
drivers/(pppos, pppou): Fix warning

### DIFF
--- a/drivers/pppos.c
+++ b/drivers/pppos.c
@@ -713,7 +713,7 @@ static int pppos_netifInit(struct netif *netif, char *cfg)
 	for (; (next = cfg_get_next_arg(cfg)); cfg = next) {
 		if (!strncmp(cfg, "/dev/", 5)) {
 			state->serialat_fn = cfg;
-			log_info("config device: ", cfg);
+			log_info("config device: %s", cfg);
 			continue;
 		}
 

--- a/drivers/pppou.c
+++ b/drivers/pppou.c
@@ -551,7 +551,7 @@ static int pppou_netifInit(struct netif *netif, char *cfg)
 
 		if (!strncmp(cfg, "/dev/", 5)) {
 			state->serial_dev = cfg;
-			log_info("config device: ", cfg);
+			log_info("config device: %s", cfg);
 			continue;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Printing cfg as string should be safe as netif driver explicitly NULL terminate between arguments and argv should be null terminated too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m7-imxrt117x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
