### PR TITLE
misc: adapt to gcc 14.2 warnings

### DIFF
--- a/drivers/ephy.c
+++ b/drivers/ephy.c
@@ -101,7 +101,7 @@ static uint32_t ephy_show_id(eth_phy_state_t *phy)
 static void ephy_show_link_state(eth_phy_state_t *phy)
 {
 	uint16_t bctl, bstat, adv, lpa, pc1, pc2;
-	int speed, full_duplex;
+	int speed, full_duplex = 0;
 
 	bctl = ephy_reg_read(phy, 0x00);
 	bstat = ephy_reg_read(phy, 0x01);
@@ -119,7 +119,7 @@ static void ephy_show_link_state(eth_phy_state_t *phy)
 
 
 	printf("lwip: ephy%u.%u link is %s %uMbps/%s (ctl %04x, status %04x, adv %04x, lpa %04x, pctl %04x,%04x)\n",
-		phy->bus, phy->addr, linkup ? "UP  " : "DOWN", speed, full_duplex ? "Full" : "Half",
+		phy->bus, phy->addr, linkup ? "UP  " : "DOWN", speed, (full_duplex != 0) ? "Full" : "Half",
 		bctl, bstat, adv, lpa, pc1, pc2);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Warnings fixed:
```
Warning: /github/workspace/phoenix-rtos-lwip/drivers/ephy.c:121:9: warning: 'full_duplex' may be used uninitialized [-Wmaybe-uninitialized]
  121 |         printf("lwip: ephy%u.%u link is %s %uMbps/%s (ctl %04x, status %04x, adv %04x, lpa %04x, pctl %04x,%04x)\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  122 |                 phy->bus, phy->addr, linkup ? "UP  " : "DOWN", speed, full_duplex ? "Full" : "Half",
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  123 |                 bctl, bstat, adv, lpa, pc1, pc2);
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/github/workspace/phoenix-rtos-lwip/drivers/ephy.c:104:20: note: 'full_duplex' was declared here
  104 |         int speed, full_duplex;
      |                    ^~~~~~~~~~~
  ```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/lwip/pull/13
- [ ] I will merge this PR by myself when appropriate.
