### PR TITLE
Fix compiler warnings caused by enabling ipv6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ CFLAGS += -Wundef -Iinclude -Ilib-lwip/src/include -I"$(LWIPOPTS_DIR)"
 
 NAME := lwip-core
 SRCS := $(LWIP_SRCS)
+# Disabling warnings from lib-lwip, as their code does not comply with these rules for now.
+LOCAL_CFLAGS += -Wno-char-subscripts -Wno-format-zero-length
 # don't install include subdir contents, these are actually internal headers
 LOCAL_HEADER_DIR := nothing
 include $(static-lib.mk)

--- a/port/sockets.c
+++ b/port/sockets.c
@@ -270,10 +270,8 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 			}
 
 			inet6_addr_to_ip6addr(&ip6addr, &sin6.sin6_addr);
-			if ((idx = netif_get_ip6_addr_match(netif, &ip6addr)) < 0) {
-				if (netif_add_ip6_address(netif, &ip6addr, &idx) != ERR_OK) {
-					return -ENOMEM;
-				}
+			if (netif_add_ip6_address(netif, &ip6addr, &idx) != ERR_OK) { /* If this function succeeds then idx >= 0 */
+				return -ENOMEM;
 			}
 
 			netif_ip6_addr_set_pref_life(netif, idx, in6_ifreq->ifra_lifetime.preferred);

--- a/port/sockets.c
+++ b/port/sockets.c
@@ -188,6 +188,7 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 			struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)&in6_ifreq->ifr_ifru.ifru_addr;
 			ip6_addr_t ip6addr;
 			s8_t idx;
+			u8_t uidx;
 			int *flags;
 			struct in6_addrlifetime *lifetime;
 
@@ -205,6 +206,7 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 			if (idx < 0) {
 				return -ENXIO;
 			}
+			uidx = (u8_t)idx;
 
 			switch (request) {
 				case SIOCGIFNETMASK_IN6:
@@ -212,12 +214,12 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 					break;
 				case SIOCGIFAFLAG_IN6:
 					flags = &in6_ifreq->ifr_ifru.ifru_flags6;
-					*flags = netif_ip6_flags(netif, idx);
+					*flags = netif_ip6_flags(netif, uidx);
 					break;
 				case SIOCGIFALIFETIME_IN6:
 					lifetime = (struct in6_addrlifetime *)&in6_ifreq->ifr_ifru.ifru_lifetime;
-					lifetime->preferred = netif_ip6_addr_pref_life(netif, idx);
-					lifetime->expire = netif_ip6_addr_valid_life(netif, idx);
+					lifetime->preferred = netif_ip6_addr_pref_life(netif, uidx);
+					lifetime->expire = netif_ip6_addr_valid_life(netif, uidx);
 					break;
 			}
 			return EOK;
@@ -257,6 +259,7 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 			struct sockaddr_in6 sin6;
 			ip6_addr_t ip6addr;
 			s8_t idx;
+			u8_t uidx;
 
 			if (netif == NULL) {
 				return -ENXIO;
@@ -274,8 +277,10 @@ static int socket_ioctl6(int sock, unsigned long request, const void *in_data, v
 				return -ENOMEM;
 			}
 
-			netif_ip6_addr_set_pref_life(netif, idx, in6_ifreq->ifra_lifetime.preferred);
-			netif_ip6_addr_set_valid_life(netif, idx, in6_ifreq->ifra_lifetime.expire);
+			uidx = (u8_t)idx;
+
+			netif_ip6_addr_set_pref_life(netif, uidx, in6_ifreq->ifra_lifetime.preferred);
+			netif_ip6_addr_set_valid_life(netif, uidx, in6_ifreq->ifra_lifetime.expire);
 			/* Ignore flags and netmask */
 
 			return EOK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixing compiler warnings introduced by https://github.com/phoenix-rtos/phoenix-rtos-lwip/pull/93

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
