### PR TITLE
wi-fi: support STA mode

### DIFF
--- a/wi-fi/lwip/main.c
+++ b/wi-fi/lwip/main.c
@@ -3,48 +3,74 @@
  *
  * LwIP Wi-Fi
  *
- * Copyright 2021 Phoenix Systems
- * Author: Ziemowit Leszczynski
+ * Copyright 2021, 2026 Phoenix Systems
+ * Author: Ziemowit Leszczynski, Julian Uziembło
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "lwip/sys.h"
+#include <ctype.h>
+#include <string.h>
+#include <sys/minmax.h>
+#include <sys/msg.h>
+#include <sys/stat.h>
+#include <posix/utils.h>
 
 #include "whd_wifi_api.h"
 #include "whd_wlioctl.h"
 #include "cybsp.h"
 #include "cybsp_wifi.h"
 #include "cy_lwip.h"
-#include "cyabs_rtos.h"
 #include "cy_lwip_log.h"
+#include "cy_log.h"
 
-#include <string.h>
-#include <sys/minmax.h>
-#include <posix/utils.h>
+#include "lwipopts.h"
+#include "netif.h"
+#include "lwip/sys.h"
 
+/* timeout for STA scanning in seconds */
+#ifndef WIFI_STA_SCAN_TIMEOUT_SECONDS
+#define WIFI_STA_SCAN_TIMEOUT_SECONDS 15
+#endif
+
+/* number of STA scans in the timeout time */
+#ifndef WIFI_STA_N_SCANS
+#define WIFI_STA_N_SCANS 3
+#endif
+
+_Static_assert(WIFI_STA_SCAN_TIMEOUT_SECONDS > 0, "STA scan timeout has to be positive");
+_Static_assert(WIFI_STA_N_SCANS > 0, "Number of STA scans has to be positive");
+_Static_assert(((float)WIFI_STA_SCAN_TIMEOUT_SECONDS / WIFI_STA_N_SCANS) >= 5.0f, "At least 5 seconds needed for every STA scan");
 
 #define WIFI_THREAD_PRIO    4
-#define WIFI_THREAD_STACKSZ (4 * _PAGE_SIZE)
+#define WIFI_THREAD_STACKSZ 4096
 
 #define WIFI_FLAG_STARTED (1U << 0)
 #define WIFI_FLAG_FAILED  (1U << 1)
 #define WIFI_FLAG_FINISH  (1U << 2)
 
-#define WIFI_START_RETRIES 5
+#define STA_DEV_ID    0
+#define STA_DEV_NAME  "/dev/wifi/sta"
+#define STA_SCAN_TYPE WHD_SCAN_TYPE_ACTIVE
+#define STA_BSS_TYPE  WHD_BSS_TYPE_ANY
 
-#define WIFI_DEV_ID   0
-#define WIFI_DEV_NAME "/dev/wifi"
-
+#define AP_DEV_ID        1
+#define AP_DEV_NAME      "/dev/wifi/ap"
 #define AP_SECURITY_MODE WHD_SECURITY_WPA2_AES_PSK
 #define AP_CHANNEL       1
 
-#define SNPRINTF_APPEND(overflow, fmt, ...) \
+#define CTRL_DEV_ID   2
+#define CTRL_DEV_NAME "/dev/wifi/ctrl"
+
+#define CONST_STRLEN(str) (sizeof(str) - 1)
+
+#define SNPRINTF_APPEND(overflow, buf, size, fmt, ...) \
 	do { \
 		if (!overflow) { \
 			int n = snprintf(buf, size, fmt, ##__VA_ARGS__); \
-			if (n >= size) \
+			if (n >= size) { \
 				overflow = true; \
+			} \
 			else { \
 				size -= n; \
 				buf += n; \
@@ -53,72 +79,76 @@
 	} while (0)
 
 
-static struct {
+struct wifi_device {
 	handle_t lock;
 	handle_t cond;
-	handle_t tid;
 
-	volatile uint8_t flags;
-	uint32_t idle_timeout;
-	uint32_t idle_current;
 	whd_ssid_t ssid;
-	uint8_t key[WSEC_MAX_PSK_LEN];
-	uint8_t key_len;
+	struct {
+		uint8_t value[WSEC_MAX_PSK_LEN];
+		uint8_t len;
+	} key;
 
+
+	bool busy;
+	int len;
+	char buf[128];
 	cy_lwip_nw_interface_t iface;
 
-	struct {
-		bool busy;
-		char buf[128];
-		int len;
-	} dev;
-} wifi_common;
+	union {
+		struct {
+			handle_t tid;
+			volatile uint8_t flags;
+			uint32_t idleCurrent;
+			uint32_t timeout;
+			ip_static_addr_t addr;
+		} apPriv;
 
-static ip_static_addr_t ap_addr = {
-	.addr = IPADDR4_INIT_BYTES(192, 168, 2, 1),
-	.netmask = IPADDR4_INIT_BYTES(255, 255, 255, 0),
-	.gateway = IPADDR4_INIT_BYTES(192, 168, 2, 1)
+		struct {
+			handle_t tid;
+			whd_scan_result_t scanResult;
+		} staPriv;
+	};
 };
 
 
-static int wifi_ap_set_idle_timeout(const char *data, size_t len)
-{
-	char buf[16];
-	long int timeout;
-	char *endp;
+enum wifi_state {
+	wifi_off,
+	wifi_idle,
+	wifi_running,
+};
 
-	if (len > (sizeof(buf) - 1)) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi idle timeout (max length is %u)\n", sizeof(buf) - 1);
-		return -1;
-	}
 
-	memcpy(buf, data, len);
-	buf[len] = '\0';
+static struct {
+	bool initialized;
+	uint32_t msgport;
+	handle_t msgtid;
 
-	errno = 0;
-	timeout = strtol(buf, &endp, 0);
-	if (errno != 0 || endp == buf) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi idle timeout (bad timeout value)\n");
-		return -1;
-	}
-	else if (timeout < 0) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi idle timeout (min value is 0)\n");
-		return -1;
-	}
-	else if (timeout > UINT32_MAX) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi idle timeout (max value is %u)\n", UINT32_MAX);
-		return -1;
-	}
-	else {
-		/* nothing */
-	}
+	union {
+		struct {
+			struct wifi_device sta;
+			struct wifi_device ap;
+		};
+		struct wifi_device dev[2];
+	};
 
-	mutexLock(wifi_common.lock);
-	wifi_common.idle_timeout = timeout;
-	mutexUnlock(wifi_common.lock);
-
-	return 0;
-}
+	struct {
+		bool busy;
+		uint32_t port;
+		int len;
+		char buf[16];
+		handle_t lock;
+		handle_t cond;
+		handle_t tid;
+	} ctrl;
+} wifi_common = {
+	.ap.apPriv.addr = {
+		/* default AP address */
+		.addr = IPADDR4_INIT_BYTES(192, 168, 2, 1),
+		.netmask = IPADDR4_INIT_BYTES(255, 255, 255, 0),
+		.gateway = IPADDR4_INIT_BYTES(192, 168, 2, 1),
+	},
+};
 
 
 static const char *trim(const char *str, size_t *len)
@@ -139,23 +169,63 @@ static const char *trim(const char *str, size_t *len)
 }
 
 
-static int wifi_ap_set_ssid(const char *ssid, size_t len)
+static int wifi_ap_set_timeout(const char *data, size_t len)
+{
+	char buf[16];
+	long int timeout;
+	char *endp;
+
+	if (len > (sizeof(buf) - 1)) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi timeout (max length is %u)\n", sizeof(buf) - 1);
+		return -1;
+	}
+
+	memcpy(buf, data, len);
+	buf[len] = '\0';
+
+	errno = 0;
+	timeout = strtol(buf, &endp, 0);
+	if (errno != 0 || endp == buf) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi timeout (bad timeout value)\n");
+		return -1;
+	}
+	else if (timeout < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi timeout (min value is 0)\n");
+		return -1;
+	}
+	else if (timeout > UINT32_MAX) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi timeout (max value is %u)\n", UINT32_MAX);
+		return -1;
+	}
+	else {
+		/* nothing */
+	}
+
+	mutexLock(wifi_common.ap.lock);
+	wifi_common.ap.apPriv.timeout = timeout;
+	mutexUnlock(wifi_common.ap.lock);
+
+	return 0;
+}
+
+
+static int wifi_set_ssid(id_t id, const char *ssid, size_t len)
 {
 	if (len > SSID_NAME_SIZE) {
 		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi SSID (max length is %u)\n", SSID_NAME_SIZE);
 		return -1;
 	}
 
-	mutexLock(wifi_common.lock);
-	memcpy(wifi_common.ssid.value, ssid, len);
-	wifi_common.ssid.length = len;
-	mutexUnlock(wifi_common.lock);
+	mutexLock(wifi_common.dev[id].lock);
+	memcpy(wifi_common.dev[id].ssid.value, ssid, len);
+	wifi_common.dev[id].ssid.length = len;
+	mutexUnlock(wifi_common.dev[id].lock);
 
 	return 0;
 }
 
 
-static int wifi_ap_set_key(const char *key, size_t len)
+static int wifi_set_key(id_t id, const char *key, size_t len)
 {
 	if (len < WSEC_MIN_PSK_LEN) {
 		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set Wi-Fi key (min length is %u)\n", WSEC_MIN_PSK_LEN);
@@ -167,30 +237,70 @@ static int wifi_ap_set_key(const char *key, size_t len)
 		return -1;
 	}
 
-	mutexLock(wifi_common.lock);
-	memcpy(wifi_common.key, key, len);
-	wifi_common.key_len = len;
-	mutexUnlock(wifi_common.lock);
+	mutexLock(wifi_common.dev[id].lock);
+	memcpy(wifi_common.dev[id].key.value, key, len);
+	wifi_common.dev[id].key.len = len;
+	mutexUnlock(wifi_common.dev[id].lock);
 
 	return 0;
 }
 
 
-static bool wifi_ap_is_idle(void)
+static void wifi_remove_interface(cy_lwip_nw_interface_t *interface)
 {
-	uint8_t buf[sizeof(uint32_t) + 4 * sizeof(whd_mac_t)];
-	whd_maclist_t *clients = (whd_maclist_t *)buf;
-	cy_rslt_t result;
+	cy_lwip_network_down(interface);
+	cy_lwip_remove_interface(interface);
+}
 
-	memset(buf, 0, sizeof(buf));
-	clients->count = 4;
 
-	result = whd_wifi_get_associated_client_list(wifi_common.iface.whd_iface, buf, sizeof(buf));
-	if (result == WHD_SUCCESS && clients->count == 0) {
-		return true;
+static whd_result_t wifi_add_interface(cy_lwip_nw_interface_t *interface, ip_static_addr_t *addr)
+{
+	whd_result_t result;
+
+	result = cy_lwip_add_interface(interface, addr);
+	if (result != CY_RSLT_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't add Wi-Fi interface\n");
+		return result;
 	}
 
-	return false;
+	result = cy_lwip_network_up(interface);
+	if (result != CY_RSLT_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't bring up Wi-Fi interface\n");
+		cy_lwip_remove_interface(interface);
+		return result;
+	}
+
+	return WHD_SUCCESS;
+}
+
+
+static enum wifi_state wifi_get_state(struct wifi_device *dev)
+{
+	if (dev->iface.whd_iface == NULL) {
+		return wifi_off;
+	}
+
+	if (dev == &wifi_common.ap) {
+		uint8_t buf[sizeof(uint32_t) + 4 * sizeof(whd_mac_t)];
+		whd_maclist_t *clients = (whd_maclist_t *)buf;
+		whd_result_t result;
+
+		memset(buf, 0, sizeof(buf));
+		clients->count = 4;
+
+		result = whd_wifi_get_associated_client_list(wifi_common.ap.iface.whd_iface, buf, sizeof(buf));
+		if (result != WHD_SUCCESS || clients->count == 0) {
+			return wifi_idle;
+		}
+
+		return wifi_running;
+	}
+	if (dev == &wifi_common.sta) {
+		return whd_wifi_is_ready_to_transceive(wifi_common.sta.iface.whd_iface) != WHD_SUCCESS ? wifi_idle : wifi_running;
+	}
+	else {
+		return wifi_idle;
+	}
 }
 
 
@@ -198,31 +308,31 @@ static void wifi_ap_main_loop(void)
 {
 	for (;;) {
 		bool finish = false;
-		bool update_idle = false;
-		bool check_idle = false;
-		unsigned int cond_timeout = 0;
+		bool updateIdle = false;
+		bool checkIdle = false;
+		unsigned int condTimeout = 0;
 
-		mutexLock(wifi_common.lock);
+		mutexLock(wifi_common.ap.lock);
 
-		if ((wifi_common.flags & WIFI_FLAG_FINISH) != 0) {
+		if ((wifi_common.ap.apPriv.flags & WIFI_FLAG_FINISH) != 0) {
 			finish = true;
 		}
 
-		if (wifi_common.idle_timeout != 0) {
-			if (wifi_common.idle_current < wifi_common.idle_timeout) {
-				update_idle = true;
-				cond_timeout = 1;
+		if (wifi_common.ap.apPriv.timeout != 0) {
+			if (wifi_common.ap.apPriv.idleCurrent < wifi_common.ap.apPriv.timeout) {
+				updateIdle = true;
+				condTimeout = 1;
 			}
 			else {
-				check_idle = true;
-				cond_timeout = 60;
+				checkIdle = true;
+				condTimeout = 60;
 			}
 		}
 
-		mutexUnlock(wifi_common.lock);
+		mutexUnlock(wifi_common.ap.lock);
 
-		if (!finish && check_idle) {
-			if (wifi_ap_is_idle()) {
+		if (!finish && checkIdle) {
+			if (wifi_get_state(&wifi_common.ap) == wifi_idle) {
 				finish = true;
 			}
 		}
@@ -231,61 +341,212 @@ static void wifi_ap_main_loop(void)
 			break;
 		}
 
-		mutexLock(wifi_common.lock);
-		condWait(wifi_common.cond, wifi_common.lock, cond_timeout * 1000000ULL);
+		mutexLock(wifi_common.ap.lock);
+		condWait(wifi_common.ap.cond, wifi_common.ap.lock, condTimeout * 1000000ULL);
 
-		if (update_idle) {
-			wifi_common.idle_current += 1;
+		if (updateIdle) {
+			wifi_common.ap.apPriv.idleCurrent += 1;
 		}
 
-		mutexUnlock(wifi_common.lock);
+		mutexUnlock(wifi_common.ap.lock);
 	}
 }
 
 
-static void wifi_deinit_interface(void)
+static void wifi_ap_thread(void *arg)
 {
-	/* All below functions are safe to call even if interface has not been initialized */
-	(void)cy_lwip_network_down(&wifi_common.iface);
-	(void)cy_lwip_remove_interface(&wifi_common.iface);
-	cybsp_wifi_deinit(wifi_common.iface.whd_iface);
-	cybsp_free();
-}
-
-
-static int wifi_init_interface(cy_lwip_nw_interface_role_t role)
-{
+	(void)arg;
+	bool started = false;
+	bool ifaceAdded = false;
 	cy_rslt_t result;
 
-	result = cybsp_init();
-	if (result != CY_RSLT_SUCCESS) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi HW\n");
+	do {
+		whd_ssid_t ssid;
+		uint8_t key[WSEC_MAX_PSK_LEN];
+		uint8_t keyLen;
+
+		mutexLock(wifi_common.ap.lock);
+		ssid = wifi_common.ap.ssid;
+		memcpy(key, wifi_common.ap.key.value, sizeof(key));
+		keyLen = wifi_common.ap.key.len;
+		mutexUnlock(wifi_common.ap.lock);
+
+		result = whd_wifi_init_ap(wifi_common.ap.iface.whd_iface, &ssid, AP_SECURITY_MODE, key, keyLen, AP_CHANNEL);
+		if (result != WHD_SUCCESS) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi AP\n");
+			break;
+		}
+
+		result = whd_wifi_start_ap(wifi_common.ap.iface.whd_iface);
+		if (result != WHD_SUCCESS) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't start Wi-Fi AP\n");
+			break;
+		}
+		started = true;
+
+		result = wifi_add_interface(&wifi_common.ap.iface, &wifi_common.ap.apPriv.addr);
+		if (result != WHD_SUCCESS) {
+			break;
+		}
+		ifaceAdded = true;
+	} while (0);
+
+	mutexLock(wifi_common.ap.lock);
+	wifi_common.ap.apPriv.flags |= (result == WHD_SUCCESS) ? WIFI_FLAG_STARTED : WIFI_FLAG_FAILED;
+	condSignal(wifi_common.ap.cond);
+	mutexUnlock(wifi_common.ap.lock);
+
+	if (result == WHD_SUCCESS) {
+		wifi_ap_main_loop();
+	}
+
+	if (started) {
+		whd_wifi_stop_ap(wifi_common.ap.iface.whd_iface);
+	}
+
+	if (ifaceAdded) {
+		wifi_remove_interface(&wifi_common.ap.iface);
+	}
+
+	wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_INFO, "AP: stopped\n");
+
+	mutexLock(wifi_common.ap.lock);
+	wifi_common.ap.apPriv.tid = 0;
+	mutexUnlock(wifi_common.ap.lock);
+}
+
+
+static void wifi_scan_result_cb(whd_scan_result_t **result_ptr, void *user_data, whd_scan_status_t status)
+{
+	switch (status) {
+		case WHD_SCAN_ABORTED:
+			return;
+
+		case WHD_SCAN_COMPLETED_SUCCESSFULLY:
+			break;
+
+		case WHD_SCAN_INCOMPLETE: {
+			if ((*result_ptr)->SSID.length != 0) {
+				whd_ssid_t *ssid = user_data;
+				if ((*result_ptr)->SSID.length != ssid->length || memcmp((*result_ptr)->SSID.value, ssid->value, ssid->length) != 0) {
+					return;
+				}
+			}
+			break;
+		}
+
+		default:
+			return;
+	}
+
+	mutexLock(wifi_common.sta.lock);
+	condSignal(wifi_common.sta.cond);
+	if (result_ptr != NULL) {
+		/* set to NULL to signal to WHD that we got what we wanted */
+		*result_ptr = NULL;
+	}
+	mutexUnlock(wifi_common.sta.lock);
+}
+
+
+static int wifi_sta_connect(void)
+{
+	whd_result_t result;
+	whd_ssid_t ssid;
+	uint8_t key[WSEC_MAX_PSK_LEN];
+	uint8_t keyLen;
+	time_t left;
+	bool wifiJoined = false;
+	bool ifaceAdded = false;
+	struct timespec tp;
+	time_t when, now;
+
+	if (wifi_get_state(&wifi_common.sta) == wifi_running) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "STA is already connected\n");
 		return -1;
 	}
 
-	result = cybsp_wifi_init_primary(&wifi_common.iface.whd_iface);
-	if (result != CY_RSLT_SUCCESS) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi interface\n");
-		cybsp_free();
-		return -1;
-	}
+	mutexLock(wifi_common.sta.lock);
 
-	wifi_common.iface.role = role;
+	ssid = wifi_common.sta.ssid;
+	memcpy(key, wifi_common.sta.key.value, sizeof(key));
+	keyLen = wifi_common.sta.key.len;
 
-	result = cy_lwip_add_interface(&wifi_common.iface, &ap_addr);
-	if (result != CY_RSLT_SUCCESS) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't add Wi-Fi interface\n");
-		cybsp_wifi_deinit(wifi_common.iface.whd_iface);
-		cybsp_free();
-		return -1;
-	}
+	mutexUnlock(wifi_common.sta.lock);
 
-	result = cy_lwip_network_up(&wifi_common.iface);
-	if (result != CY_RSLT_SUCCESS) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't bring up Wi-Fi interface\n");
-		cy_lwip_remove_interface(&wifi_common.iface);
-		cybsp_wifi_deinit(wifi_common.iface.whd_iface);
-		cybsp_free();
+	left = WIFI_STA_SCAN_TIMEOUT_SECONDS;
+
+	do {
+		result = whd_wifi_set_ioctl_value(wifi_common.sta.iface.whd_iface, WLC_SET_BAND, WLC_BAND_AUTO);
+		if (result != WHD_SUCCESS) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "couldn't set auto band on interface\n");
+			break;
+		}
+
+		if (clock_gettime(CLOCK_MONOTONIC, &tp) < 0) {
+			result = WHD_SCAN_ABORTED;
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "couldn't get current time: %s (%d)\n", strerror(errno), errno);
+			break;
+		}
+		now = tp.tv_sec;
+		when = now + WIFI_STA_SCAN_TIMEOUT_SECONDS;
+
+		mutexLock(wifi_common.sta.lock);
+		memset(&wifi_common.sta.staPriv.scanResult, 0, sizeof(wifi_common.sta.staPriv.scanResult));
+		wifi_common.sta.staPriv.scanResult.security = WHD_SECURITY_UNKNOWN;
+		do {
+			left = when - now;
+			if (left <= 0) {
+				result = WHD_SCAN_ABORTED;
+				break;
+			}
+			result = whd_wifi_scan(wifi_common.sta.iface.whd_iface, STA_SCAN_TYPE, STA_BSS_TYPE,
+					&ssid, NULL, NULL, NULL, wifi_scan_result_cb, &wifi_common.sta.staPriv.scanResult, &ssid);
+			condWait(wifi_common.sta.cond, wifi_common.sta.lock, min((WIFI_STA_SCAN_TIMEOUT_SECONDS * 1000000ULL) / WIFI_STA_N_SCANS, left * 1000000ULL));
+
+			(void)whd_wifi_stop_scan(wifi_common.sta.iface.whd_iface);
+
+			if (clock_gettime(CLOCK_MONOTONIC, &tp) < 0) {
+				result = WHD_SCAN_ABORTED;
+				wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "couldn't get current time: %s (%d)\n", strerror(errno), errno);
+				break;
+			}
+			now = tp.tv_sec;
+			if (now >= when) {
+				result = WHD_SCAN_ABORTED;
+				break;
+			}
+		} while (result == WHD_SUCCESS && wifi_common.sta.staPriv.scanResult.security == WHD_SECURITY_UNKNOWN);
+
+		if (result != WHD_SUCCESS) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't get network's security\n");
+			mutexUnlock(wifi_common.sta.lock);
+			break;
+		}
+
+		result = whd_wifi_join_specific(wifi_common.sta.iface.whd_iface, &wifi_common.sta.staPriv.scanResult, key, keyLen);
+		if (result != WHD_SUCCESS) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't join requested network\n");
+			mutexUnlock(wifi_common.sta.lock);
+			break;
+		}
+		mutexUnlock(wifi_common.sta.lock);
+		wifiJoined = true;
+
+		result = wifi_add_interface(&wifi_common.sta.iface, NULL);
+		if (result != WHD_SUCCESS) {
+			break;
+		}
+		ifaceAdded = true;
+	} while (0);
+
+	if (result != WHD_SUCCESS) {
+		if (ifaceAdded) {
+			wifi_remove_interface(&wifi_common.sta.iface);
+		}
+		if (wifiJoined) {
+			whd_wifi_leave(wifi_common.sta.iface.whd_iface);
+		}
 		return -1;
 	}
 
@@ -293,60 +554,14 @@ static int wifi_init_interface(cy_lwip_nw_interface_role_t role)
 }
 
 
-static void wifi_ap_thread(void *arg)
+static void wifi_sta_disconnect(void)
 {
-	bool started = false;
-
-	do {
-		cy_rslt_t result;
-		whd_ssid_t ssid;
-		uint8_t key[WSEC_MAX_PSK_LEN];
-		uint8_t key_len;
-
-		mutexLock(wifi_common.lock);
-
-		ssid = wifi_common.ssid;
-		memcpy(key, wifi_common.key, sizeof(key));
-		key_len = wifi_common.key_len;
-
-		mutexUnlock(wifi_common.lock);
-
-		if (wifi_init_interface(CY_LWIP_AP_NW_INTERFACE) < 0) {
-			break;
-		}
-
-		result = whd_wifi_init_ap(wifi_common.iface.whd_iface, &ssid, AP_SECURITY_MODE, key, key_len, AP_CHANNEL);
-		if (result != WHD_SUCCESS) {
-			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi AP\n");
-			wifi_deinit_interface();
-			break;
-		}
-
-		result = whd_wifi_start_ap(wifi_common.iface.whd_iface);
-		if (result != WHD_SUCCESS) {
-			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't start Wi-Fi AP\n");
-			wifi_deinit_interface();
-			break;
-		}
-
-		started = true;
-	} while (0);
-
-	mutexLock(wifi_common.lock);
-	wifi_common.flags |= started ? WIFI_FLAG_STARTED : WIFI_FLAG_FAILED;
-	condSignal(wifi_common.cond);
-	mutexUnlock(wifi_common.lock);
-
-	if (started) {
-		wifi_ap_main_loop();
-
-		whd_wifi_stop_ap(wifi_common.iface.whd_iface);
-		wifi_deinit_interface();
+	if (wifi_get_state(&wifi_common.sta) != wifi_running) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "STA is not connected\n");
+		return;
 	}
-
-	mutexLock(wifi_common.lock);
-	wifi_common.tid = 0;
-	mutexUnlock(wifi_common.lock);
+	wifi_remove_interface(&wifi_common.sta.iface);
+	whd_wifi_leave(wifi_common.sta.iface.whd_iface);
 }
 
 
@@ -354,31 +569,31 @@ static int wifi_ap_start(void)
 {
 	uint8_t flags;
 
-	mutexLock(wifi_common.lock);
+	mutexLock(wifi_common.ap.lock);
 
 	/* reset idle timeout in any case */
-	wifi_common.idle_current = 0;
+	wifi_common.ap.apPriv.idleCurrent = 0;
 
-	if (wifi_common.tid != 0) {
-		mutexUnlock(wifi_common.lock);
+	if (wifi_common.ap.apPriv.tid != 0) {
+		mutexUnlock(wifi_common.ap.lock);
 		return 0;
 	}
 
-	wifi_common.flags = 0;
+	wifi_common.ap.apPriv.flags = 0;
 
-	if (sys_thread_opt_new("wifi-ap", wifi_ap_thread, NULL, WIFI_THREAD_STACKSZ, WIFI_THREAD_PRIO, &wifi_common.tid) < 0) {
-		mutexUnlock(wifi_common.lock);
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi AP thread\n");
+	if (sys_thread_opt_new("wifi-ap", wifi_ap_thread, NULL, WIFI_THREAD_STACKSZ, WIFI_THREAD_PRIO, &wifi_common.ap.apPriv.tid) < 0) {
+		mutexUnlock(wifi_common.ap.lock);
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create AP thread\n");
 		return -1;
 	}
 
-	while (wifi_common.flags == 0) {
-		condWait(wifi_common.cond, wifi_common.lock, 0);
+	while (wifi_common.ap.apPriv.flags == 0) {
+		condWait(wifi_common.ap.cond, wifi_common.ap.lock, 0);
 	}
 
-	flags = wifi_common.flags;
+	flags = wifi_common.ap.apPriv.flags;
 
-	mutexUnlock(wifi_common.lock);
+	mutexUnlock(wifi_common.ap.lock);
 
 	return ((flags & WIFI_FLAG_STARTED) != 0) ? 0 : -1;
 }
@@ -388,102 +603,142 @@ static void wifi_ap_stop(void)
 {
 	handle_t tid;
 
-	mutexLock(wifi_common.lock);
+	mutexLock(wifi_common.ap.lock);
 
-	if (wifi_common.tid == 0) {
-		mutexUnlock(wifi_common.lock);
+	if (wifi_common.ap.apPriv.tid == 0) {
+		mutexUnlock(wifi_common.ap.lock);
 		return;
 	}
 
-	tid = wifi_common.tid;
-	wifi_common.flags |= WIFI_FLAG_FINISH;
-	condSignal(wifi_common.cond);
+	tid = wifi_common.ap.apPriv.tid;
+	wifi_common.ap.apPriv.flags |= WIFI_FLAG_FINISH;
+	condSignal(wifi_common.ap.cond);
 
-	mutexUnlock(wifi_common.lock);
+	mutexUnlock(wifi_common.ap.lock);
 
 	sys_thread_join(tid);
 }
 
 
-static int wifi_dev_open(int flags)
+static int wifi_sta_get_connected(whd_ssid_t *ssid)
+{
+	whd_bss_info_t info;
+	__attribute__((unused)) whd_security_t security;
+	whd_result_t result = whd_wifi_get_ap_info(wifi_common.sta.iface.whd_iface, &info, &security);
+	if (result != WHD_SUCCESS) {
+		return -1;
+	}
+
+	if (ssid != NULL) {
+		memcpy(ssid->value, info.SSID, sizeof(ssid->value));
+		ssid->length = info.SSID_len;
+	}
+
+	return 0;
+}
+
+
+static int wifi_dev_open(id_t id, int flags)
 {
 	char *buf;
 	size_t size;
 	bool overflow = false;
 
-	if (wifi_common.dev.busy) {
+	if (wifi_common.dev[id].busy) {
 		return -EBUSY;
 	}
 
-	buf = wifi_common.dev.buf;
-	size = sizeof(wifi_common.dev.buf);
+	buf = wifi_common.dev[id].buf;
+	size = sizeof(wifi_common.dev[id].buf);
 
-	mutexLock(wifi_common.lock);
+	mutexLock(wifi_common.dev[id].lock);
 
-	SNPRINTF_APPEND(overflow, "running=%u\n", wifi_common.tid != 0);
-	SNPRINTF_APPEND(overflow, "timeout=%u\n", wifi_common.idle_timeout);
-	SNPRINTF_APPEND(overflow, "ssid=%.*s\n", wifi_common.ssid.length, wifi_common.ssid.value);
+	if (id == STA_DEV_ID) {
+		SNPRINTF_APPEND(overflow, buf, size, "ssid=%.*s\n", wifi_common.sta.ssid.length, wifi_common.sta.ssid.value);
+		enum wifi_state state = wifi_get_state(&wifi_common.sta);
+		if (state == wifi_running) {
+			whd_ssid_t ssid;
+			if (wifi_sta_get_connected(&ssid) < 0) {
+				wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "Failed to get SSID of connected network\n");
+			}
+			else {
+				SNPRINTF_APPEND(overflow, buf, size, "current=%.*s\n", ssid.length, ssid.value);
+			}
+		}
+		SNPRINTF_APPEND(overflow, buf, size, "running=%u\n", state == wifi_running ? 1U : 0U);
+	}
+	else if (id == AP_DEV_ID) {
+		SNPRINTF_APPEND(overflow, buf, size, "timeout=%u\n", wifi_common.ap.apPriv.timeout);
+		SNPRINTF_APPEND(overflow, buf, size, "ssid=%.*s\n", wifi_common.ap.ssid.length, wifi_common.ap.ssid.value);
+		SNPRINTF_APPEND(overflow, buf, size, "running=%u\n", wifi_common.ap.apPriv.tid != 0);
+	}
+	else {
+		/* nothing */
+	}
 
-	mutexUnlock(wifi_common.lock);
+
+	mutexUnlock(wifi_common.dev[id].lock);
 
 	if (overflow) {
 		return -EFBIG;
 	}
 
-	wifi_common.dev.busy = true;
-	wifi_common.dev.len = buf - wifi_common.dev.buf;
+	wifi_common.dev[id].busy = true;
+	wifi_common.dev[id].len = buf - wifi_common.dev[id].buf;
 
 	return 0;
 }
 
 
-static int wifi_dev_close(void)
+static int wifi_dev_close(id_t id)
 {
-	if (!wifi_common.dev.busy) {
+	if (!wifi_common.dev[id].busy) {
 		return -EBADF;
 	}
-	wifi_common.dev.busy = false;
+	wifi_common.dev[id].busy = false;
 	return 0;
 }
 
 
-static int wifi_dev_read(char *data, size_t size, off_t offset)
+static int wifi_dev_read(id_t id, char *data, size_t size, off_t offset)
 {
 	int cnt;
 
-	if (offset > wifi_common.dev.len) {
+	if (offset > wifi_common.dev[id].len) {
 		return -ERANGE;
 	}
 
-	cnt = min(size, wifi_common.dev.len - offset);
-	memcpy(data, wifi_common.dev.buf + offset, cnt);
+	cnt = min(size, wifi_common.dev[id].len - offset);
+	memcpy(data, wifi_common.dev[id].buf + offset, cnt);
 
 	return cnt;
 }
 
 
-static int wifi_dev_write(const char *data, size_t size)
+static int wifi_dev_write(id_t id, const char *data, size_t size)
 {
+	const size_t inputSize = size;
 	data = trim(data, &size);
 
-	if (size >= 8 && strncmp("timeout ", data, 8) == 0) {
-		wifi_ap_set_idle_timeout(data + 8, size - 8);
+	if (size >= CONST_STRLEN("ssid ") && strncmp("ssid ", data, 5) == 0) {
+		wifi_set_ssid(id, data + 5, size - 5);
 	}
-	else if (size >= 5 && strncmp("ssid ", data, 5) == 0) {
-		wifi_ap_set_ssid(data + 5, size - 5);
+	else if (size >= CONST_STRLEN("key ") && strncmp("key ", data, 4) == 0) {
+		wifi_set_key(id, data + 4, size - 4);
 	}
-	else if (size >= 4 && strncmp("key ", data, 4) == 0) {
-		wifi_ap_set_key(data + 4, size - 4);
+	else if (id == STA_DEV_ID && size == CONST_STRLEN("connect") && strncmp("connect", data, size) == 0) {
+		wifi_sta_connect();
 	}
-	else if (strncmp("start", data, size) == 0) {
-		unsigned int retries = WIFI_START_RETRIES;
-
-		while (wifi_ap_start() < 0 && retries-- > 0) {
-			/* FIXME: temporary workaround - find out why AP doesn't start */
-			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "retrying to start Wi-Fi AP\n");
-		}
+	else if (id == STA_DEV_ID && size == CONST_STRLEN("disconnect") && strncmp("disconnect", data, size) == 0) {
+		wifi_sta_disconnect();
 	}
-	else if (strncmp("stop", data, size) == 0) {
+	else if (id == AP_DEV_ID && size >= CONST_STRLEN("timeout ") && strncmp("timeout ", data, 8) == 0) {
+		wifi_ap_set_timeout(data + 8, size - 8);
+	}
+	else if (id == AP_DEV_ID && size == CONST_STRLEN("start") && strncmp("start", data, size) == 0) {
+		wifi_ap_start();
+	}
+	else if (id == AP_DEV_ID && size == CONST_STRLEN("stop") && strncmp("stop", data, size) == 0) {
 		wifi_ap_stop();
 	}
 	else {
@@ -491,70 +746,387 @@ static int wifi_dev_write(const char *data, size_t size)
 		return -EINVAL;
 	}
 
-	return size;
+	return inputSize;
 }
 
 
-static int wifi_dev_init(unsigned int port)
+static int wifi_dev_init(unsigned int port, id_t id, const char *path)
 {
-	oid_t wifi_oid = { port, WIFI_DEV_ID };
+	oid_t wifi_oid = { port, id };
 
-	return create_dev(&wifi_oid, WIFI_DEV_NAME);
+	return create_dev(&wifi_oid, path);
 }
 
 
 static void wifi_msg_thread(void *arg)
 {
-	cy_rslt_t result;
-	unsigned int port;
-
-	result = cy_log_init(CY_LOG_INFO);
-	if (result != CY_RSLT_SUCCESS) {
-		fprintf(stderr, "phoenix-rtos-lwip: can't init Wi-Fi logs\n");
-		return;
-	}
-
-	if (portCreate(&port) < 0) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi port\n");
-		return;
-	}
-
-	if (wifi_dev_init(port) < 0) {
-		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi device\n");
-		return;
-	}
-
 	for (;;) {
 		msg_t msg = { 0 };
 		msg_rid_t rid;
 
-		if (msgRecv(port, &msg, &rid) < 0) {
+		if (msgRecv(wifi_common.msgport, &msg, &rid) < 0) {
+			/* should signalize that our port was closed */
+			wifi_common.msgport = 0;
+			break;
+		}
+
+		if ((msg.oid.id != STA_DEV_ID && msg.oid.id != AP_DEV_ID) || !wifi_common.initialized) {
+			msg.o.err = -ENODEV;
+			msgRespond(wifi_common.msgport, &msg, rid);
 			continue;
 		}
 
 		switch (msg.type) {
 			case mtOpen:
-				msg.o.err = wifi_dev_open(msg.i.openclose.flags);
+				msg.o.err = wifi_dev_open(msg.oid.id, msg.i.openclose.flags);
 				break;
 
 			case mtClose:
-				msg.o.err = wifi_dev_close();
+				msg.o.err = wifi_dev_close(msg.oid.id);
 				break;
 
 			case mtRead:
-				msg.o.err = wifi_dev_read(msg.o.data, msg.o.size, msg.i.io.offs);
+				msg.o.err = wifi_dev_read(msg.oid.id, msg.o.data, msg.o.size, msg.i.io.offs);
 				break;
 
 			case mtWrite:
-				msg.o.err = wifi_dev_write(msg.i.data, msg.i.size);
+				msg.o.err = wifi_dev_write(msg.oid.id, msg.i.data, msg.i.size);
 				break;
 
 			default:
-				msg.o.err = -EINVAL;
+				msg.o.err = -EOPNOTSUPP;
 				break;
 		}
 
-		msgRespond(port, &msg, rid);
+		(void)msgRespond(wifi_common.msgport, &msg, rid);
+	}
+}
+
+
+static int wifi_init_interfaces(void)
+{
+	cy_rslt_t result;
+
+	result = cybsp_init();
+	if (result != CY_RSLT_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi HW\n");
+		return -1;
+	}
+
+	/* STA */
+	result = cybsp_wifi_init_primary(&wifi_common.sta.iface.whd_iface);
+	if (result != CY_RSLT_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi primary interface (STA)\n");
+		cybsp_free();
+		wifi_common.sta.iface.whd_iface = NULL;
+		return -1;
+	}
+
+	wifi_common.sta.iface.role = CY_LWIP_STA_NW_INTERFACE;
+
+	/* AP */
+	result = cybsp_wifi_init_secondary(&wifi_common.ap.iface.whd_iface, NULL);
+	if (result != CY_RSLT_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't init Wi-Fi secondary interface (AP)\n");
+		cybsp_wifi_deinit(wifi_common.sta.iface.whd_iface);
+		cybsp_free();
+		wifi_common.sta.iface.whd_iface = NULL;
+		wifi_common.ap.iface.whd_iface = NULL;
+		return -1;
+	}
+
+	wifi_common.ap.iface.role = CY_LWIP_AP_NW_INTERFACE;
+
+	return 0;
+}
+
+
+static void wifi_deinit_interfaces(void)
+{
+	handle_t tid;
+
+	mutexLock(wifi_common.ap.lock);
+	tid = wifi_common.ap.apPriv.tid;
+	mutexUnlock(wifi_common.ap.lock);
+
+	if (tid != 0) {
+		wifi_ap_stop();
+	}
+
+	/* checks internally if STA is connected */
+	wifi_sta_disconnect();
+
+	/* cybsp_wifi_deinit() deinitializes both interfaces - only needs the
+	  interface pointer to get the driver pointer, so it needs to be
+	  called only once on any of the interfaces */
+	if (wifi_common.sta.iface.whd_iface != NULL) {
+		cybsp_wifi_deinit(wifi_common.sta.iface.whd_iface);
+		cybsp_free();
+	}
+	else if (wifi_common.ap.iface.whd_iface != NULL) {
+		cybsp_wifi_deinit(wifi_common.ap.iface.whd_iface);
+		cybsp_free();
+	}
+	else {
+		/* nothing */
+	}
+	wifi_common.sta.iface.whd_iface = NULL;
+	wifi_common.ap.iface.whd_iface = NULL;
+}
+
+
+static void _wifi_deinit(void)
+{
+	destroy_dev(AP_DEV_NAME);
+	destroy_dev(STA_DEV_NAME);
+
+	if (wifi_common.msgport != (uint32_t)-1) {
+		portDestroy(wifi_common.msgport);
+		wifi_common.msgport = (uint32_t)-1;
+		/* only wait for thread if we can signalize for it to close with portDestroy */
+		if (wifi_common.msgtid != 0) {
+			sys_thread_join(wifi_common.msgtid);
+			wifi_common.msgtid = 0;
+		}
+	}
+
+	wifi_deinit_interfaces();
+	if (wifi_common.sta.lock != -1) {
+		resourceDestroy(wifi_common.sta.lock);
+		wifi_common.sta.lock = -1;
+	}
+	if (wifi_common.sta.cond != -1) {
+		resourceDestroy(wifi_common.sta.cond);
+		wifi_common.sta.cond = -1;
+	}
+	if (wifi_common.ap.lock != -1) {
+		resourceDestroy(wifi_common.ap.lock);
+		wifi_common.ap.lock = -1;
+	}
+	if (wifi_common.ap.cond != -1) {
+		resourceDestroy(wifi_common.ap.cond);
+		wifi_common.ap.cond = -1;
+	}
+	wifi_common.initialized = false;
+}
+
+
+static void wifi_deinit(void)
+{
+	mutexLock(wifi_common.ctrl.lock);
+	if (!wifi_common.initialized) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "Wi-Fi is not up\n");
+	}
+	else {
+		_wifi_deinit();
+	}
+	mutexUnlock(wifi_common.ctrl.lock);
+}
+
+
+static int _wifi_init(void)
+{
+	int err;
+
+	wifi_common.msgport = (uint32_t)-1;
+	wifi_common.msgtid = 0;
+	wifi_common.sta.lock = -1;
+	wifi_common.sta.cond = -1;
+	wifi_common.ap.lock = -1;
+	wifi_common.ap.cond = -1;
+
+	do {
+		err = portCreate(&wifi_common.msgport);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi port\n");
+			break;
+		}
+
+		err = mutexCreate(&wifi_common.sta.lock);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create STA lock\n");
+			break;
+		}
+
+		err = condCreate(&wifi_common.sta.cond);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create STA cond\n");
+			break;
+		}
+
+		err = mutexCreate(&wifi_common.ap.lock);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create AP lock\n");
+			break;
+		}
+
+		err = condCreate(&wifi_common.ap.cond);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create AP cond\n");
+			break;
+		}
+
+		err = wifi_init_interfaces();
+		if (err < 0) {
+			break;
+		}
+
+		err = wifi_dev_init(wifi_common.msgport, STA_DEV_ID, STA_DEV_NAME);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi STA device\n");
+			break;
+		}
+
+		err = wifi_dev_init(wifi_common.msgport, AP_DEV_ID, AP_DEV_NAME);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi AP device\n");
+			break;
+		}
+
+		/* keep this as the last thing here so that we don't have to deinitialize it on error */
+		err = sys_thread_opt_new("wifi-msg", wifi_msg_thread, NULL, WIFI_THREAD_STACKSZ, WIFI_THREAD_PRIO, &wifi_common.msgtid);
+		if (err < 0) {
+			wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi msgthread\n");
+			break;
+		}
+	} while (0);
+
+	if (err < 0) {
+		_wifi_deinit();
+	}
+	else {
+		wifi_common.initialized = true;
+	}
+
+	return err;
+}
+
+
+static int wifi_init(void)
+{
+	int err;
+
+	mutexLock(wifi_common.ctrl.lock);
+	if (wifi_common.initialized) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "Wi-Fi is already initialized\n");
+		err = -1;
+	}
+	else {
+		err = _wifi_init();
+	}
+	mutexUnlock(wifi_common.ctrl.lock);
+
+	if (err < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "failed to initialize Wi-Fi\n");
+	}
+
+	return err;
+}
+
+
+static void wifi_ctrl_thread(void *arg)
+{
+	msg_t msg;
+	msg_rid_t rid;
+
+	int err = mutexCreate(&wifi_common.ctrl.lock);
+	if (err < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "could not create ctrl lock\n");
+		return;
+	}
+
+	err = condCreate(&wifi_common.ctrl.cond);
+	if (err < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "could not create ctrl cond\n");
+		resourceDestroy(wifi_common.ctrl.lock);
+		return;
+	}
+
+	err = portCreate(&wifi_common.ctrl.port);
+	if (err < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "could not create ctrl port\n");
+		resourceDestroy(wifi_common.ctrl.lock);
+		resourceDestroy(wifi_common.ctrl.cond);
+		return;
+	}
+
+	if (wifi_dev_init(wifi_common.ctrl.port, CTRL_DEV_ID, CTRL_DEV_NAME) < 0) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't create Wi-Fi ctrl device\n");
+		resourceDestroy(wifi_common.ctrl.lock);
+		resourceDestroy(wifi_common.ctrl.cond);
+		portDestroy(wifi_common.ctrl.port);
+		return;
+	}
+
+	for (;;) {
+		if (msgRecv(wifi_common.ctrl.port, &msg, &rid) < 0) {
+			continue;
+		}
+
+		switch (msg.type) {
+			case mtOpen: {
+				if (wifi_common.ctrl.busy) {
+					msg.o.err = -EBUSY;
+					break;
+				}
+
+				mutexLock(wifi_common.ctrl.lock);
+				bool running = wifi_common.initialized;
+				mutexUnlock(wifi_common.ctrl.lock);
+
+				int bytes = snprintf(wifi_common.ctrl.buf, sizeof(wifi_common.ctrl.buf), "running=%d\n", running ? 1 : 0);
+				wifi_common.ctrl.len = bytes;
+				wifi_common.ctrl.busy = true;
+				msg.o.err = EOK;
+				break;
+			}
+
+			case mtClose:
+				wifi_common.ctrl.busy = false;
+				msg.o.err = EOK;
+				break;
+
+			case mtRead: {
+				off_t offset = msg.i.io.offs;
+				if (offset > wifi_common.ctrl.len) {
+					msg.o.err = -ERANGE;
+					break;
+				}
+
+				int cnt = min(msg.o.size, wifi_common.ctrl.len - offset);
+
+				memcpy(msg.o.data, wifi_common.ctrl.buf + offset, cnt);
+				msg.o.err = cnt;
+				break;
+			}
+
+			case mtWrite: {
+				const char *data = msg.i.data;
+				size_t size = msg.i.size;
+
+				data = trim(data, &size);
+
+				if (size == CONST_STRLEN("on") && strncmp("on", data, size) == 0) {
+					wifi_init();
+				}
+				else if (size == CONST_STRLEN("off") && strncmp("off", data, size) == 0) {
+					wifi_deinit();
+				}
+				else {
+					wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "got unknown Wi-Fi command: %.*s\n", (int)size, data);
+					msg.o.err = -EINVAL;
+					break;
+				}
+				msg.o.err = msg.i.size;
+				break;
+			}
+
+			default:
+				msg.o.err = -EOPNOTSUPP;
+				break;
+		}
+
+		(void)msgRespond(wifi_common.ctrl.port, &msg, rid);
 	}
 }
 
@@ -563,21 +1135,13 @@ __constructor__(1000) void init_wifi(void)
 {
 	int err;
 
-	err = mutexCreate(&wifi_common.lock);
-	if (err < 0) {
-		errout(err, "mutexCreate(lock)");
+	if (cy_log_init(CY_LOG_INFO) != CY_RSLT_SUCCESS) {
+		errout(-ENOSYS, "can't init Wi-Fi logs\n");
 	}
 
-	err = condCreate(&wifi_common.cond);
+	err = sys_thread_opt_new("wifi-ctrl", wifi_ctrl_thread, NULL, WIFI_THREAD_STACKSZ, WIFI_THREAD_PRIO, NULL);
 	if (err < 0) {
-		resourceDestroy(wifi_common.lock);
-		errout(err, "condCreate(cond)");
-	}
-
-	err = sys_thread_opt_new("wifi-msg", wifi_msg_thread, NULL, WIFI_THREAD_STACKSZ, WIFI_THREAD_PRIO, NULL);
-	if (err < 0) {
-		resourceDestroy(wifi_common.lock);
-		resourceDestroy(wifi_common.cond);
+		cy_log_shutdown();
 		errout(err, "thread(wifi-msg)");
 	}
 }

--- a/wi-fi/lwip/main.c
+++ b/wi-fi/lwip/main.c
@@ -121,6 +121,24 @@ static int wifi_ap_set_idle_timeout(const char *data, size_t len)
 }
 
 
+static const char *trim(const char *str, size_t *len)
+{
+	size_t sz = *len;
+	while (sz > 0 && !isgraph(*str)) {
+		str++;
+		sz--;
+	}
+
+	while (sz > 0 && !isgraph(str[sz - 1])) {
+		sz--;
+	}
+
+	*len = sz;
+
+	return str;
+}
+
+
 static int wifi_ap_set_ssid(const char *ssid, size_t len)
 {
 	if (len > SSID_NAME_SIZE) {
@@ -446,6 +464,8 @@ static int wifi_dev_read(char *data, size_t size, off_t offset)
 
 static int wifi_dev_write(const char *data, size_t size)
 {
+	data = trim(data, &size);
+
 	if (size >= 8 && strncmp("timeout ", data, 8) == 0) {
 		wifi_ap_set_idle_timeout(data + 8, size - 8);
 	}

--- a/wi-fi/lwip/main.c
+++ b/wi-fi/lwip/main.c
@@ -92,7 +92,7 @@ struct wifi_device {
 
 	bool busy;
 	int len;
-	char buf[128];
+	char buf[192];
 	cy_lwip_nw_interface_t iface;
 
 	union {
@@ -664,12 +664,19 @@ static int wifi_dev_open(id_t id, int flags)
 			else {
 				SNPRINTF_APPEND(overflow, buf, size, "current=%.*s\n", ssid.length, ssid.value);
 			}
+			struct netif *netif = cy_lwip_get_interface(wifi_common.dev[id].iface.role);
+			SNPRINTF_APPEND(overflow, buf, size, "ipaddr=%s\n", netif != NULL ? ipaddr_ntoa(&netif->ip_addr) : "unknown");
+			SNPRINTF_APPEND(overflow, buf, size, "netmask=%s\n", netif != NULL ? ipaddr_ntoa(&netif->netmask) : "unknown");
+			SNPRINTF_APPEND(overflow, buf, size, "gateway=%s\n", netif != NULL ? ipaddr_ntoa(&netif->gw) : "unknown");
 		}
 		SNPRINTF_APPEND(overflow, buf, size, "running=%u\n", state == wifi_running ? 1U : 0U);
 	}
 	else if (id == AP_DEV_ID) {
 		SNPRINTF_APPEND(overflow, buf, size, "timeout=%u\n", wifi_common.ap.apPriv.timeout);
 		SNPRINTF_APPEND(overflow, buf, size, "ssid=%.*s\n", wifi_common.ap.ssid.length, wifi_common.ap.ssid.value);
+		SNPRINTF_APPEND(overflow, buf, size, "ipaddr=%s\n", ipaddr_ntoa(&wifi_common.ap.apPriv.addr.addr));
+		SNPRINTF_APPEND(overflow, buf, size, "netmask=%s\n", ipaddr_ntoa(&wifi_common.ap.apPriv.addr.netmask));
+		SNPRINTF_APPEND(overflow, buf, size, "gateway=%s\n", ipaddr_ntoa(&wifi_common.ap.apPriv.addr.gateway));
 		SNPRINTF_APPEND(overflow, buf, size, "running=%u\n", wifi_common.ap.apPriv.tid != 0);
 	}
 	else {
@@ -715,6 +722,27 @@ static int wifi_dev_read(id_t id, char *data, size_t size, off_t offset)
 }
 
 
+static int wifi_set_addr(ip_addr_t *addr, const char *data, size_t size)
+{
+	char addrStr[sizeof("255.255.255.255")] = { 0 };
+	if (size > sizeof(addrStr) - 1) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "IP too long: %.*s\n", size, data);
+		return -1;
+	}
+
+	size = min(size, sizeof(addrStr) - 1);
+	memcpy(addrStr, data, size);
+
+	if (ip4addr_aton(addrStr, addr) != 0) {
+		return 0;
+	}
+	else {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "bad IP address: %.*s\n", size, data);
+		return -1;
+	}
+}
+
+
 static int wifi_dev_write(id_t id, const char *data, size_t size)
 {
 	const size_t inputSize = size;
@@ -740,6 +768,15 @@ static int wifi_dev_write(id_t id, const char *data, size_t size)
 	}
 	else if (id == AP_DEV_ID && size == CONST_STRLEN("stop") && strncmp("stop", data, size) == 0) {
 		wifi_ap_stop();
+	}
+	else if (id == AP_DEV_ID && size >= CONST_STRLEN("ipaddr ") && strncmp("ipaddr ", data, 7) == 0) {
+		wifi_set_addr(&wifi_common.ap.apPriv.addr.addr, data + 7, size - 7);
+	}
+	else if (id == AP_DEV_ID && size >= CONST_STRLEN("netmask ") && strncmp("netmask ", data, 8) == 0) {
+		wifi_set_addr(&wifi_common.ap.apPriv.addr.netmask, data + 8, size - 8);
+	}
+	else if (id == AP_DEV_ID && size >= CONST_STRLEN("gateway ") && strncmp("gateway ", data, 8) == 0) {
+		wifi_set_addr(&wifi_common.ap.apPriv.addr.gateway, data + 8, size - 8);
 	}
 	else {
 		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "got unknown Wi-Fi command: %.*s\n", (int)size, data);

--- a/wi-fi/lwip/main.c
+++ b/wi-fi/lwip/main.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <posix/utils.h>
 
+#include "whd_events_int.h"
 #include "whd_wifi_api.h"
 #include "whd_wlioctl.h"
 #include "cybsp.h"
@@ -840,6 +841,21 @@ static void wifi_msg_thread(void *arg)
 }
 
 
+static void *wifi_handle_error(whd_driver_t whd_driver, const uint8_t *error_type, const uint8_t *event_data, void *handler_user_data)
+{
+	if (*error_type == WLC_ERR_BUS) {
+		msg_t msg = {
+			.oid = { .id = CTRL_DEV_ID, .port = wifi_common.ctrl.port },
+			.type = mtWrite,
+			.i.data = "off",
+			.i.size = sizeof("off") - 1,
+		};
+		msgSend(wifi_common.ctrl.port, &msg);
+	}
+	return NULL;
+}
+
+
 static int wifi_init_interfaces(void)
 {
 	cy_rslt_t result;
@@ -860,6 +876,17 @@ static int wifi_init_interfaces(void)
 	}
 
 	wifi_common.sta.iface.role = CY_LWIP_STA_NW_INTERFACE;
+
+	/* error handler - deinitialize Wi-Fi on bus fail */
+	const uint8_t err = WLC_ERR_BUS;
+	uint16_t index;
+	if (whd_wifi_set_error_handler(wifi_common.sta.iface.whd_iface, &err, &wifi_handle_error, NULL, &index) != WHD_SUCCESS) {
+		wm_cy_log_msg(CYLF_MIDDLEWARE, CY_LOG_ERR, "can't set error handler\n");
+		cybsp_wifi_deinit(wifi_common.sta.iface.whd_iface);
+		cybsp_free();
+		wifi_common.sta.iface.whd_iface = NULL;
+		return -1;
+	}
 
 	/* AP */
 	result = cybsp_wifi_init_secondary(&wifi_common.ap.iface.whd_iface, NULL);

--- a/wi-fi/whd/bus_protocols/whd_bus_usb_protocol.c
+++ b/wi-fi/whd/bus_protocols/whd_bus_usb_protocol.c
@@ -83,6 +83,7 @@ static struct {
         cy_queue_t queue;
         cy_semaphore_t semaphore;
         cy_thread_t thread;
+        bool failed;
     } rx;
 } whd_bus_usb_common;
 
@@ -347,7 +348,9 @@ static void whd_bus_usb_rx_thread(cy_thread_arg_t arg)
             if (result != WHD_SUCCESS) {
                 whd_buffer_release(whd_driver, buffer, WHD_NETWORK_RX);
                 if (result == WHD_BUS_FAIL && !cyhal_usb_check_state(whd_bus_usb_common.config.path)) {
-                    WPRINT_WHD_ERROR(("%s: bus failed, exiting\n", __FUNCTION__));
+                    WPRINT_WHD_ERROR(("%s: bus failed - device disconnected, exiting\n", __FUNCTION__));
+                    whd_bus_usb_common.rx.failed = true;
+                    whd_thread_notify(whd_driver);
                     break;
                 }
                 cy_rtos_delay_milliseconds(10);
@@ -628,6 +631,10 @@ static whd_bool_t whd_bus_usb_wake_interrupt_present(whd_driver_t whd_driver)
  **************************************************************************************************/
 static uint32_t whd_bus_usb_packet_available_to_read(whd_driver_t whd_driver)
 {
+    if (whd_bus_usb_common.rx.failed) {
+        return WHD_BUS_FAIL;
+    }
+
     size_t count;
     (void)cy_rtos_queue_count(&whd_bus_usb_common.rx.queue, &count);
     return count;

--- a/wi-fi/whd/whd_thread.c
+++ b/wi-fi/whd/whd_thread.c
@@ -427,6 +427,7 @@ static void whd_thread_func(cy_thread_arg_t thread_input)
             WPRINT_WHD_ERROR( ("%s: Error bus_fail over %d times\n", __FUNCTION__, WHD_MAX_BUS_FAIL) );
             error_type = WLC_ERR_BUS;
             whd_set_error_handler_locally(whd_driver, &error_type, NULL, NULL, NULL);
+            break;
         }
 
         /* Sleep till WLAN do something */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds STA mode to Wi-Fi manager. For easier Wi-Fi management, the `/dev/wifi` device had to be split into three devices:
- `/dev/wifi/ctrl`: Wi-Fi state management: on/off. Putting Wi-Fi "on" initializes the WHD interfaces: STA as primary and AP as secondary. It also creates the latter 2 devices for managing STA and AP modes.
- `/dev/wifi/sta`: STA mode management: set idle timeout, set SSID and key of the network you want to connect to, connect/disconnect.
- `/dev/wifi/ap`: AP mode management: set idle timeout, set SSID and key of the access point, start/stop (API unchanged)

Idle timeout should always be set `!= 0` in both modes as it is used to periodically check if the bus is still operational (the bus can fail if e.g. device gets disconnected).

This PR also adds by default, concurrent mode (AP+STA together at the same time) is enabled. To disable it, define WIFI_CONCURRENT_MODE_ENABLED to 0 in `lwipopts.h`.

This PR also allows setting AP static address by writing to `/dev/wifi/ap`:
- "ip_addr a.b.c.d" for IP address
- "netmask a.b.c.d" for netmask
- "gateway a.b.c.d" for gateway address
Written address is only validated if it itself is valid. It is
not checked for being a valid interface/netmask/gateway address.
This check is only done on AP start.

This PR also also adds IP reporting on read:
- AP reports its static IP, netmask, gateway
- STA reports its dynamic IP, netmask, gateway

## Motivation and Context
STA mode (client mode) needed on some platforms (especially imxrt).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change):
    - `/dev/wifi` device split into three devices (described in "Description" section above)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt117x-evk`,  `armv7a7-imx6ull-dataro`, NILEE.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-lwip/pull/118 - *maybe not necessary, but needed to run on imrt117x with Sterling LWB5+ USB dongle*
    - https://github.com/phoenix-rtos/libphoenix/pull/466
- [ ] I will merge this PR by myself when appropriate.
