### PR TITLE
Support for 88E1111

### DIFF
--- a/drivers/ephy.c
+++ b/drivers/ephy.c
@@ -130,6 +130,13 @@ enum {
 	EPHY_DP83867IS_D3_SGMIICTL1 = 0xD3 /* SGMIICTL1 (via MMD access) */
 };
 
+/* 88E1111-specific registers*/
+enum {
+	EPHY_88E1111_11_PHYSR = 0x11, /* PHY Specific Status */
+	EPHY_88E1111_12_IER,          /* Interrupt Enable */
+	EPHY_88E1111_13_ISR,          /* Interrupt Status */
+};
+
 
 #define ephy_printf(phy, fmt, ...) printf("lwip: ephy%u.%u: " fmt "\n", phy->bus, phy->addr, ##__VA_ARGS__)
 
@@ -238,7 +245,7 @@ static uint32_t ephy_readPhyId(const eth_phy_state_t *phy)
 
 static void ephy_setLinkState(const eth_phy_state_t *phy)
 {
-	uint16_t bctl, bstat, adv, lpa, pc1, pc2;
+	uint16_t bctl, bstat, adv, lpa, pc1, pc2, physr;
 	int speed, full_duplex = 0;
 
 	bctl = ephy_regRead(phy, EPHY_COMMON_00_BMCR);
@@ -274,6 +281,11 @@ static void ephy_setLinkState(const eth_phy_state_t *phy)
 		case ephy_rtl8201fi:
 			ephy_printf(phy, "link is %s %uMbps/%s (ctl %04x, status %04x, adv %04x, lpa %04x)",
 					(linkup != 0) ? "UP  " : "DOWN", speed, (full_duplex != 0) ? "Full" : "Half", bctl, bstat, adv, lpa);
+			break;
+		case ephy_88e1111:
+			physr = ephy_regRead(phy, EPHY_88E1111_11_PHYSR);
+			ephy_printf(phy, "link is %s %uMbps/%s (ctl %04x, status %04x, adv %04x, lpa %04x psts %04x)",
+					(linkup != 0) ? "UP  " : "DOWN", speed, (full_duplex != 0) ? "Full" : "Half", bctl, bstat, adv, lpa, physr);
 			break;
 		case ephy_rtl8211fdi:
 			pc1 = ephy_regRead(phy, EPHY_RTL8211_18_PHYCR1);
@@ -397,6 +409,32 @@ static inline int ephy_rtl8211fdi_linkSpeed(const eth_phy_state_t *phy, int *ful
 }
 
 
+static inline int ephy_88e1111_linkSpeed(const eth_phy_state_t *phy, int *full_duplex)
+{
+	uint16_t physr = ephy_regRead(phy, EPHY_88E1111_11_PHYSR);
+	uint16_t speed;
+
+	if (full_duplex != NULL) {
+		*full_duplex = ((physr & (1U << 13)) != 0) ? 1 : 0;
+	}
+
+	speed = (physr >> 14) & 0x3U;
+
+	ephy_debug_printf(phy, "speed: %d", speed);
+
+	switch (speed) {
+		case 0x2:
+			return 1000;
+		case 0x1:
+			return 100;
+		case 0x0:
+			return 10;
+		default:
+			return 0;
+	}
+}
+
+
 int ephy_linkSpeed(const eth_phy_state_t *phy, int *full_duplex)
 {
 	switch (phy->model) {
@@ -412,6 +450,8 @@ int ephy_linkSpeed(const eth_phy_state_t *phy, int *full_duplex)
 			return ephy_rtl8201fi_linkSpeed(phy, full_duplex);
 		case ephy_rtl8211fdi:
 			return ephy_rtl8211fdi_linkSpeed(phy, full_duplex);
+		case ephy_88e1111:
+			return ephy_88e1111_linkSpeed(phy, full_duplex);
 		default:
 			/* unreachable */
 			return 0;
@@ -551,6 +591,9 @@ static __attribute__((unused)) char *ephy_parsePhyModel(eth_phy_state_t *phy, ch
 	}
 	else if (strcmp(cfg, "rtl8211fdi-cg") == 0) {
 		phy->model = ephy_rtl8211fdi;
+	}
+	else if (strcmp(cfg, "88e1111") == 0) {
+		phy->model = ephy_88e1111;
 	}
 	else {
 		printf("lwip: ephy: unsupported PHY model: \"%s\"\n", cfg);
@@ -900,6 +943,10 @@ int ephy_init(eth_phy_state_t *phy, char *conf, uint8_t board_rev, link_state_cb
 			phy->irq.reg = EPHY_RTL8211_1D_INSR;
 			phy->irq.mask = 0x06BD;
 			break;
+		case ephy_88e1111:
+			phy->irq.reg = EPHY_88E1111_13_ISR;
+			phy->irq.mask = 0x0400;
+			break;
 		default:
 			/* unreachable */
 			break;
@@ -942,6 +989,9 @@ int ephy_init(eth_phy_state_t *phy, char *conf, uint8_t board_rev, link_state_cb
 			break;
 		case ephy_rtl8211fdi:
 			ephy_regWrite(phy, EPHY_RTL8211_12_INER, (1U << 4));
+			break;
+		case ephy_88e1111:
+			ephy_regWrite(phy, EPHY_88E1111_12_IER, (1U << 10));
 			break;
 		default:
 			/* unreachable */

--- a/drivers/ephy.h
+++ b/drivers/ephy.h
@@ -25,7 +25,9 @@ typedef struct {
 		ephy_ksz9031mnx,
 		ephy_dp83867is,
 		ephy_rtl8201fi,
-		ephy_rtl8211fdi } model;
+		ephy_rtl8211fdi,
+		ephy_88e1111,
+	} model;
 	unsigned bus;
 	unsigned addr;
 	unsigned reset_hold_time_us;

--- a/drivers/greth.c
+++ b/drivers/greth.c
@@ -185,7 +185,11 @@ static uint16_t greth_mdioIO(greth_state_t *state, unsigned addr, unsigned reg, 
 
 static int greth_mdioSetup(void *arg, unsigned max_khz, unsigned min_hold_ns, unsigned opt_preamble)
 {
-	/* GR740 turn on PHY interrupts */
+	(void)max_khz;
+	(void)min_hold_ns;
+	(void)opt_preamble;
+
+	/* Greth turn on PHY interrupts */
 	greth_state_t *state = arg;
 	state->mmio->CTRL |= GRETH_CTRL_PI;
 	return 0;

--- a/drivers/greth.c
+++ b/drivers/greth.c
@@ -40,7 +40,7 @@
 #define GRETH_MAC_IAB      UINT64_C(0x0050C275A000) /* Gaisler research AB */
 #define GRETH_RX_RING_SIZE 8
 #define GRETH_TX_RING_SIZE 8
-#define GRETH_MAX_PKT_SZ   1514
+#define GRETH_MAX_PKT_SZ   (1514 + ETH_PAD_SIZE)
 
 #ifndef GRETH_EDCL
 #define GRETH_EDCL 0
@@ -265,7 +265,7 @@ static size_t greth_nextRxBufferSize(const net_bufdesc_ring_t *ring, size_t i)
 		printf("lwip: greth: WARNING: This message indicates a potential HW bug:\n");
 		printf("lwip: greth: HW provided invalid size: %zu. Setting size to 1\n", sz);
 	}
-	return sz;
+	return sz + ETH_PAD_SIZE;
 }
 
 
@@ -283,7 +283,7 @@ static void greth_fillRxDesc(const net_bufdesc_ring_t *ring, size_t i, addr_t pa
 	volatile greth_buf_desc_t *desc = (volatile greth_buf_desc_t *)ring->ring + i;
 	unsigned wrap = desc == (volatile greth_buf_desc_t *)ring->ring + ring->last ? GRETH_DESC_WR : 0;
 
-	desc->addr = pa;
+	desc->addr = pa + ETH_PAD_SIZE;
 
 	atomic_thread_fence(memory_order_seq_cst);
 	desc->flags = GRETH_DESC_EN | GRETH_DESC_IE | wrap;


### PR DESCRIPTION
Add support for PHY 88E1111 and fix `greth` driver bug with rx and `ETH_PAD_SIZE`. 

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-gr765-vcu118`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
