### PR TITLE
greth: remove aligned attribute from interrupt handler

### DIFF
--- a/drivers/greth.c
+++ b/drivers/greth.c
@@ -87,7 +87,7 @@ static void greth_disableEdcl(greth_state_t *state)
 #endif
 
 
-__attribute__((section(".interrupt"), aligned(0x1000))) static int greth_irqHandler(unsigned int n, void *arg)
+__attribute__((section(".interrupt"))) static int greth_irqHandler(unsigned int n, void *arg)
 {
 	(void)n;
 	greth_state_t *state = arg;


### PR DESCRIPTION
Attribute no longer necessary with the introduction of custom LD script on riscv64.

YT: RTOS-126

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
