### PR TITLE
drivers/pktmem: fix race in net_freePktBuf()

### DIFF
--- a/drivers/pktmem.c
+++ b/drivers/pktmem.c
@@ -156,10 +156,10 @@ static void net_freePktBuf(void *bufp, void *pktmem_start)
 	unsigned which = ((size_t)bufp - (size_t)pktmem_start) / pktmem_opts.pkt_buf_sz;
 	unsigned old_mask;
 
+	SYS_ARCH_PROTECT(old_level);
+
 	old_mask = info->free_mask;
 	info->free_mask |= 1u << which;
-
-	SYS_ARCH_PROTECT(old_level);
 
 	++pkt_bufs_free;
 


### PR DESCRIPTION
net_freePktBuf() read and modified info->free_mask before acquiring SYS_ARCH_PROTECT.

This race was introduced in commit 2cbd39ee4a7895d4f6893130f28eaedb87ab4591.

YT: RTOS-507

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
