### PR TITLE
drivers/rtl8139cp: lower TX and RX thread priorities to reasonable amounts

### DIFF
--- a/drivers/rtl8139cp.c
+++ b/drivers/rtl8139cp.c
@@ -320,8 +320,8 @@ static int rtl_initDevice(rtl_priv_t *state, uint16_t devnum, int irq)
 	if ((err = rtl_initRings(state)) != EOK)
 		goto err_exit;
 
-	beginthread(rtl_rx_irq_thread, 0, (void *)state->rx_stack, sizeof(state->rx_stack), state);
-	beginthread(rtl_tx_irq_thread, 0, (void *)state->tx_stack, sizeof(state->tx_stack), state);
+	beginthread(rtl_rx_irq_thread, 4, (void *)state->rx_stack, sizeof(state->rx_stack), state);
+	beginthread(rtl_tx_irq_thread, 4, (void *)state->tx_stack, sizeof(state->tx_stack), state);
 	interrupt(irq, rtl_rx_irq_handler, state, state->rx_irq_cond, &state->rx_irq_handle);
 	interrupt(irq, rtl_tx_irq_handler, state, state->tx_irq_cond, &state->tx_irq_handle);
 


### PR DESCRIPTION
TX and RX threads should not have the priority 0 as they will hang the system when a constant stream of data is received. Their prios are now lowered to 4.

Fixes: phoenix-rtos/phoenix-rtos-project#1611

... at least partially - if problem with memory persists, the issue should be re-opened.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
