### PR TITLE
wi-fi/lwip: fix AP network shutdown

### DIFF
--- a/wi-fi/lwip/cy_lwip.c
+++ b/wi-fi/lwip/cy_lwip.c
@@ -690,9 +690,10 @@ cy_rslt_t cy_lwip_network_down(cy_lwip_nw_interface_t *iface)
 	}
 
 #if LWIP_IPV4
-	if (is_dhcp_client_required) {
+	if (iface->role == CY_LWIP_STA_NW_INTERFACE && is_dhcp_client_required) {
 #if LWIP_AUTOIP
-		if (netif_autoip_data(IP_HANDLE(iface->role))->state == AUTOIP_STATE_BOUND) {
+		struct autoip *autoip = netif_autoip_data(IP_HANDLE(iface->role));
+		if (autoip != NULL && autoip->state == AUTOIP_STATE_BOUND) {
 			/*
              * If LPA is enabled, invoke activity callback to resume the network stack,
              * before invoking the lwip APIs that requires TCP Core lock.


### PR DESCRIPTION
In cy_lwip_network_down, netif should only be checked for DHCP if its role is STA (as is done everywhere else in the code).

YT: RTOS-1350

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt117x-evk`, `armv7a7-imx6ull-dataro`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
