### PR TITLE
port/socket: Add missing return

### DIFF
--- a/port/sockets.c
+++ b/port/sockets.c
@@ -311,6 +311,8 @@ static int socket_ioctl(int sock, unsigned long request, const void *in_data, vo
 			res = netif_index_to_name(ifreq->ifr_ifindex, ifreq->ifr_name);
 			if (res == NULL)
 				return -ENXIO;
+
+			return EOK;
 		}
 
 		case SIOCGIFINDEX: {

--- a/port/sockets.c
+++ b/port/sockets.c
@@ -320,9 +320,9 @@ static int socket_ioctl(int sock, unsigned long request, const void *in_data, vo
 				return -ENXIO;
 
 			ifreq->ifr_ifindex = netif_get_index(interface);
-		}
 
 			return EOK;
+		}
 
 		case SIOCGIFFLAGS: {
 			/*


### PR DESCRIPTION
Behavior should remain same, this will skip unnecessary operations

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add missing return on SIOCGIFNAME ioctl handling. This change should not change behavior as it just skips call to functions that handling SIOCGIFINDEX ioctl (reverse operation), which should always succeed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Verification code base against -Wimplicit-fallthrough=3
See: https://github.com/phoenix-rtos/phoenix-rtos-build/pull/285

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu.

Verification code:
```c
#include <sys/socket.h>
#include <stdio.h>
#include <net/if.h>

int main(void)
{
	for (int i = 0; i < 5; i++) {
		char name[IF_NAMESIZE];
		const char *res = if_indextoname(i, name);

		printf("%d: %s\n", i, res);
	}
	return 0;
}
```

Result:

BEFORE change:
```
(psh)% /usr/bin/hello
0: (null)
1: lo0
2: en1
3: (null)
4: (null)
```

AFTER change:
```
(psh)% /usr/bin/hello
0: (null)
1: lo0
2: en1
3: (null)
4: (null)
```
NOTE: Not an obvious to create good automatic test for that.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
